### PR TITLE
Option :typecast for key works with load document

### DIFF
--- a/lib/mongo_mapper/plugins/keys/key.rb
+++ b/lib/mongo_mapper/plugins/keys/key.rb
@@ -38,7 +38,11 @@ module MongoMapper
             end
           end
 
-          type.from_mongo(value)
+          if options[:typecast].present?
+            type.from_mongo(value).map! { |v| typecast_class.from_mongo(v) }
+          else
+            type.from_mongo(value)
+          end
         end
 
         def set(value)
@@ -48,7 +52,7 @@ module MongoMapper
             end
           end
         end
-        
+
         private
           def typecast_class
             @typecast_class ||= options[:typecast].constantize

--- a/test/unit/test_key.rb
+++ b/test/unit/test_key.rb
@@ -101,6 +101,21 @@ class KeyTest < Test::Unit::TestCase
     end
   end
 
+  context "for an array with :typecast option of Date" do
+    setup   { @key = Key.new(:dates, Array, :typecast => 'Date') }
+    subject { @key }
+
+    should "cast each element correctly when get" do
+      dates = [Date.yesterday, Date.today, Date.tomorrow.to_s]
+      subject.get(dates).should == dates.map { |date| Date.from_mongo(date) }
+    end
+
+    should "cast each element correctly when set" do
+      dates = [Date.yesterday, Date.today, Date.tomorrow.to_s]
+      subject.set(dates).should == dates.map { |date| Date.to_mongo(date) }
+    end
+  end
+
   context "for a set with :typecast option" do
     setup   { @key = Key.new(:user_ids, Set, :typecast => 'ObjectId') }
     subject { @key }


### PR DESCRIPTION
Hello, I found use :typecast with Array key like this, when load document from mongodb, mm will not convert elements to expected type, so created this patch to resolve it, hope it helps.

```
class User
  include MongoMapper::Document

  key :tweets,           Array, :typecast => 'Hashie::Mash'
end
```
