### PR TITLE
Multi-parameter mass-assignment support

### DIFF
--- a/lib/mongo_mapper/document.rb
+++ b/lib/mongo_mapper/document.rb
@@ -34,6 +34,7 @@ module MongoMapper
         plugin Plugins::Userstamps
         plugin Plugins::Validations
         plugin Plugins::Callbacks # for now callbacks needs to be after validations
+        plugin Plugins::MultiParameter
       end
       super
     end

--- a/lib/mongo_mapper/plugins/accessible.rb
+++ b/lib/mongo_mapper/plugins/accessible.rb
@@ -21,14 +21,6 @@ module MongoMapper
           super(filter_inaccessible_attrs(attrs))
         end
 
-        def update_attributes(attrs={})
-          super(filter_inaccessible_attrs(attrs))
-        end
-
-        def update_attributes!(attrs={})
-          super(filter_inaccessible_attrs(attrs))
-        end
-
         def accessible_attributes
           self.class.accessible_attributes
         end
@@ -36,7 +28,9 @@ module MongoMapper
         protected
           def filter_inaccessible_attrs(attrs)
             return attrs if accessible_attributes.blank? || attrs.blank?
-            attrs.dup.delete_if { |key, val| !accessible_attributes.include?(key.to_sym) }
+            attrs.dup.delete_if do |key, val| 
+              !accessible_attributes.include?(key.to_s.split("(").first.to_sym)
+            end
           end
       end
     end

--- a/lib/mongo_mapper/plugins/multi_parameter.rb
+++ b/lib/mongo_mapper/plugins/multi_parameter.rb
@@ -1,0 +1,127 @@
+# encoding: UTF-8
+
+module MongoMapper
+
+  class MultiParamAssign < Error; end
+
+  module Plugins
+    module MultiParameter
+      module InstanceMethods
+        def attributes=(attrs={})
+          multi_parameter_attrs = get_multi_parameter_attrs attrs
+          attrs = filter_multi_parameter_attrs attrs
+
+          # assign regular attributes.
+          super attrs
+
+          # assign multi-parameter attributes.
+          set_multi_parameter_attrs multi_parameter_attrs
+        end
+
+        protected
+
+        def get_multi_parameter_attrs attrs
+          multi_parameter_attrs = []
+          attrs.each do |k, v|
+            if k.include? "("
+              multi_parameter_attrs << [ k, v ]
+            end
+          end
+          multi_parameter_attrs
+        end
+
+        def filter_multi_parameter_attrs attrs
+          attrs.reject do |k, v|
+            k.include? "("
+          end
+        end
+
+        def set_multi_parameter_attrs pairs
+          callstack = extract_callstack_for_multiparameter_attributes pairs
+          execute_callstack_for_multiparameter_attributes callstack
+        end
+
+        # Comes from the rails source code. Modified to work in MM context without any ActiveRecord dependencies.
+        def execute_callstack_for_multiparameter_attributes(callstack)
+          errors = []
+          callstack.each do |name, values_with_empty_parameters|
+            begin
+              unless self.keys[name].nil?
+                begin
+                  # Not using String#classify because it doesn't exist in standard ruby.
+                  klass = eval "#{self.keys[name].type}"
+                rescue
+                  "Key type of attribute named #{name} isn't a class name... can't assign as multiparameter attribute."
+                end
+              else
+                raise "Trying to assign a multiparameter attribute named #{name}. No such key was defined."
+              end
+              # in order to allow a date to be set without a year, we must keep the empty values.
+              # Otherwise, we wouldn't be able to distinguish it from a date with an empty day.
+              values = values_with_empty_parameters.reject { |v| v.nil? }
+
+              if values.empty?
+                send(name + "=", nil)
+              else
+                value = if Time == klass
+                          instantiate_time_object(name, values)
+                        elsif Date == klass
+                          begin
+                            values = values_with_empty_parameters.collect do |v| v.nil? ? 1 : v end
+                            Date.new(*values)
+                          rescue ArgumentError => ex # if Date.new raises an exception on an invalid date
+                            instantiate_time_object(name, values).to_date # we instantiate Time object and convert it back to a date thus using Time's logic in handling invalid dates
+                          end
+                        else
+                          klass.new(*values)
+                        end
+
+                send(name + "=", value)
+              end
+            rescue => ex
+              errors << ex
+            end
+          end
+          unless errors.empty?
+            raise MultiParamAssign.new "#{errors.size} error(s) on assignment of multiparameter attributes"
+          end
+        end
+
+        # Comes from the rails source code.
+        def extract_callstack_for_multiparameter_attributes(pairs)
+          attributes = {}
+
+          for pair in pairs
+            multiparameter_name, value = pair
+            attribute_name = multiparameter_name.split("(").first
+            attributes[attribute_name] = [] unless attributes.include?(attribute_name)
+
+            parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
+            attributes[attribute_name] << [ find_parameter_position(multiparameter_name), parameter_value ]
+          end
+
+          attributes.each { |name, values| attributes[name] = values.sort_by{ |v| v.first }.collect { |v| v.last } }
+        end
+
+        # Comes from the rails source code.
+        def find_parameter_position multiparameter_name
+          multiparameter_name.scan(/\(([0-9]*).*\)/).first.first
+        end
+
+        # Comes from the rails source code.
+        def type_cast_attribute_value(multiparameter_name, value)
+          multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
+        end
+
+        # Comes from the rails source code.
+        def instantiate_time_object(name, values)
+          #if self.class.send(:create_time_zone_conversion_attribute?, name, column_for_attribute(name))
+          #Time.zone.local(*values)
+          #else
+          Time.time_with_datetime_fallback(@@default_timezone, *values)
+          #end
+        end
+      end
+    end
+  end
+end

--- a/lib/mongo_mapper/plugins/protected.rb
+++ b/lib/mongo_mapper/plugins/protected.rb
@@ -30,14 +30,6 @@ module MongoMapper
           super(filter_protected_attrs(attrs))
         end
 
-        def update_attributes(attrs={})
-          super(filter_protected_attrs(attrs))
-        end
-
-        def update_attributes!(attrs={})
-          super(filter_protected_attrs(attrs))
-        end
-
         def protected_attributes
           self.class.protected_attributes
         end
@@ -45,7 +37,9 @@ module MongoMapper
         protected
           def filter_protected_attrs(attrs)
             return attrs if protected_attributes.blank? || attrs.blank?
-            attrs.dup.delete_if { |key, val| protected_attributes.include?(key.to_sym) }
+            attrs.dup.delete_if do |key, val| 
+              protected_attributes.include?(key.to_s.split("(").first.to_sym)
+            end
           end
       end
     end

--- a/test/functional/test_accessible.rb
+++ b/test/functional/test_accessible.rb
@@ -6,8 +6,9 @@ class AccessibleTest < Test::Unit::TestCase
       @doc_class = Doc do
         key :name, String
         key :admin, Boolean, :default => false
+				key :some_date, Date
 
-        attr_accessible :name
+        attr_accessible :name, :some_date
       end
 
       @doc = @doc_class.create(:name => 'Steve Sloan')
@@ -78,6 +79,11 @@ class AccessibleTest < Test::Unit::TestCase
 
     should "accept nil as constructor's argument without raising exception" do
       lambda { @doc_class.new(nil) }.should_not raise_error
+    end
+
+    should "accept multi-parameter assignments of accessible attributes" do
+      @doc.update_attributes!("some_date(1i)" => "2000")
+      assert_not_nil? @doc.some_date
     end
   end
 

--- a/test/functional/test_multi_parameter.rb
+++ b/test/functional/test_multi_parameter.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class MultiParameterTest < Test::Unit::TestCase
+  context 'A document with a Date attribute' do
+    setup do
+      @doc_class = Doc do
+        key :some_date, Date
+      end
+
+      @doc = @doc_class.create
+    end
+
+    should 'be able to receive a date as multiple parameters through mass assignment' do
+      @doc_class.update_attributes! "some_date(i1)" => "2000"
+      assert_not_nil @doc.some_date
+    end
+  end
+end

--- a/test/functional/test_protected.rb
+++ b/test/functional/test_protected.rb
@@ -6,6 +6,7 @@ class ProtectedTest < Test::Unit::TestCase
       @doc_class = Doc do
         key :name, String
         key :admin, Boolean, :default => false
+				key :some_date, Date
 
         attr_protected :admin
       end
@@ -84,6 +85,11 @@ class ProtectedTest < Test::Unit::TestCase
 
     should "accept nil as constructor's argument without raising exception" do
       lambda { @doc_class.new(nil) }.should_not raise_error
+    end
+
+    should "accept multi-parameter assignments of unprotected attributes" do
+      @doc.update_attributes!("some_date(1i)" => "2000")
+      assert_not_nil? @doc.some_date
     end
   end
 


### PR DESCRIPTION
Hello,

I implemented support for multi-parameter assignments. What I did :
- I mostly adapted some active_record source code, so that is how they implemented it in active_record.
- I removed all dependencies on active_record just in case some of your users use MM in regular ruby. (using #eval instead of String#classify for instance.)
- I replaced active_record reflection with the simple MM keys typing. (Having schema definition on the app side is great!)

As a side note :
- I removed unnecessary calls to the #filter_\* functions in the accessible and protected plugins because they were already called in #assign and it is always called.

Feel free to tell me what you don't like and what I should change before you pull.

BTW, I've been using MM for a day and a half and I find it's a great tool. Thanks for all your work.
