### PR TITLE
Rails3

### DIFF
--- a/lib/mongo_mapper/plugins/dirty.rb
+++ b/lib/mongo_mapper/plugins/dirty.rb
@@ -19,7 +19,7 @@ module MongoMapper
         end
 
         def save(*)
-          super.tap { changed_attributes.clear }
+          super.tap { |saved| changed_attributes.clear if saved }
         end
 
         def save!(*)

--- a/test/functional/test_dirty.rb
+++ b/test/functional/test_dirty.rb
@@ -160,4 +160,21 @@ class DirtyTest < Test::Unit::TestCase
       milestone.changed.should == %w(project_id)
     end
   end
+
+  context "save with an invalid document" do
+    should "not clear changes" do
+      validated_class = Doc do
+        key :name, String
+        key :required, String, :required=>true
+      end
+      validated_doc = validated_class.new
+      validated_doc.name = "I'm a changin"
+      validated_doc.save
+      validated_doc.changed?.should be_true
+
+      validated_doc.required = 1
+      validated_doc.save
+      validated_doc.changed?.should be_false
+    end
+  end
 end


### PR DESCRIPTION
Rewriting the save method using tap in the dirty plugin bypassed the logic that prevented clearing changes if save returns false. I added a test case for this scenario, and modified the save method to clear changes only when super returns true.
