### PR TITLE
Validating associated

### DIFF
--- a/lib/mongo_mapper/plugins/validations.rb
+++ b/lib/mongo_mapper/plugins/validations.rb
@@ -58,7 +58,7 @@ module MongoMapper
 
       class AssociatedValidator < ::ActiveModel::EachValidator
         def validate_each(record, attribute, value)
-          if !Array.wrap(value).all? { |c| c.nil? || c.valid? }
+          if !Array.wrap(value).all? { |c| c.nil? || c.valid?(record.validation_context) }
             record.errors.add(attribute, :invalid, :default => options[:message], :value => value)
           end
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,7 +64,8 @@ class Test::Unit::TestCase
   end
 
   custom_matcher :have_error_on do |receiver, matcher, args|
-    receiver.valid?
+    context = args[2]
+    receiver.valid?(context)
     attribute = args[0]
     expected_message = args[1]
 

--- a/test/unit/test_validations.rb
+++ b/test/unit/test_validations.rb
@@ -546,4 +546,39 @@ class ValidationsTest < Test::Unit::TestCase
         doc.should_not have_error_on(:action)
       end
     end
+
+  context "validating associated" do
+    setup do
+      @topic = Doc('Topic') do
+        key :title
+      end
+      @reply = EDoc('Reply') do
+        key :content
+      end
+    end
+
+    should "validate associated many with custom validation context" do
+      @topic.many :replies, :class => @reply
+      @topic.validates_associated :replies, :on => :custom_context
+      @reply.validates_presence_of :content, :on => :custom_context
+
+      topic = @topic.new
+      topic.replies << @reply.new
+      topic.should_not have_error_on(:replies)
+      topic.should have_error_on(:replies, nil, :custom_context)
+      topic.replies[0].errors[:content].join.should =~ /blank/
+    end
+
+    should "validate associated one with custom validation context" do
+      @topic.one :reply, :class => @reply
+      @topic.validates_associated :reply, :on => :custom_context
+      @reply.validates_presence_of :content, :on => :custom_context
+
+      topic = @topic.new
+      topic.reply = @reply.new
+      topic.should_not have_error_on(:reply)
+      topic.should have_error_on(:reply, nil, :custom_context)
+      topic.reply.errors[:content].join.should =~ /blank/
+    end
+  end
 end


### PR DESCRIPTION
I am using custom validation contexts for document validation under certain conditions. However, I noticed that the context passed to the valid? method was not being propagated down to the valid? call on the associated document. This should fix that issue.
