### PR TITLE
Rails3 fix for test:prepare

### DIFF
--- a/lib/mongo_mapper/railtie/database.rake
+++ b/lib/mongo_mapper/railtie/database.rake
@@ -56,3 +56,5 @@ namespace :db do
     end
   end
 end
+
+task 'test:prepare' => 'db:test:prepare'


### PR DESCRIPTION
I noticed that when running tests my test database was never actually being cleaned out. Though the railties/database.rake have a db:test:prepare task defined the test:prepare task was never calling it. I simply made test:prepare dependent on db:test:prepare and now the test database is cleaned out on each test run.
