### PR TITLE
assign id to embedded document when initializing with hash.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,20 +8,23 @@ PATH
 
 GEM
   specs:
-    activemodel (3.0.0)
-      activesupport (= 3.0.0)
+    activemodel (3.0.0.beta3)
+      activesupport (= 3.0.0.beta3)
+    activesupport (3.0.0.beta3)
       builder (~> 2.1.2)
-      i18n (~> 0.4.1)
-    activesupport (3.0.0)
+      i18n (~> 0.3.6)
+      memcache-client (>= 1.7.5)
+      tzinfo (~> 0.3.16)
     bson (1.1)
     bson_ext (1.1)
     builder (2.1.2)
-    i18n (0.4.2)
+    i18n (0.3.7)
     jnunemaker-matchy (0.4.0)
     jnunemaker-validatable (1.8.4)
       activesupport (>= 2.3.4)
     json (1.4.6)
     log_buddy (0.5.0)
+    memcache-client (1.8.5)
     mocha (0.9.8)
       rake
     mongo (1.1)
@@ -31,7 +34,7 @@ GEM
     rake (0.8.7)
     shoulda (2.11.3)
     timecop (0.3.5)
-    tzinfo (0.3.23)
+    tzinfo (0.3.22)
 
 PLATFORMS
   ruby

--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -167,6 +167,7 @@ module MongoMapper
 
         def initialize_from_database(attrs={})
           @_new = false
+          default_id_value(attrs)
           load_from_database(attrs)
           self
         end

--- a/test/functional/associations/test_one_embedded_proxy.rb
+++ b/test/functional/associations/test_one_embedded_proxy.rb
@@ -77,5 +77,18 @@ class OneEmbeddedProxyTest < Test::Unit::TestCase
     post.author = @author_class.new(:name => 'Frank')
     post.author?.should be_true
   end
+  
+  should "initialize id for nested embedded document created from hash" do
+    @address_class = EDoc('Address') do
+      key :city, String
+      key :state, String
+    end
+    @author_class.one :address, :class => @address_class
+    @post_class.one :author, :class => @author_class
+
+    post = @post_class.create(:title => 'Post Title', :author => { :name => 'Frank', :address => { :city => 'Boston', :state => 'MA' } })
+
+    post.author.address.id.should_not be_nil    
+  end
 
 end


### PR DESCRIPTION
When initializing a document containing an embedded document with a hash, the _id was not set for the embedded document. 

doc = Doc.new :embedded_doc => { :some_key => "some value" }
   =>   doc.embedded_doc.id == nil

patch ensures doc.embedded_doc == ObjectID
