### PR TITLE
Edoc save bang

### DIFF
--- a/lib/mongo_mapper/plugins/embedded_document.rb
+++ b/lib/mongo_mapper/plugins/embedded_document.rb
@@ -34,9 +34,8 @@ module MongoMapper
         end
 
         def save!(options={})
-          _root_document.try(:save, options).tap do |result|
-            @_new = false if result
-          end
+          valid? || raise(DocumentNotValid.new(self))
+          _root_document.save!(options)
         end
 
         def _root_document

--- a/test/unit/test_embedded_document.rb
+++ b/test/unit/test_embedded_document.rb
@@ -34,13 +34,26 @@ class EmbeddedDocumentTest < Test::Unit::TestCase
 
         key :other_child, String
       end
+      
+      class ::EDocWithAValidation
+        include MongoMapper::EmbeddedDocument
+        key :name, String, :required => true
+      end
+      
+      class ::DocWithAValidation
+        include MongoMapper::Document
+        key :name, String, :required => true
+        many :e_doc_with_a_validations
+      end
     end
 
     teardown do
-      Object.send :remove_const, 'Grandparent' if defined?(::Grandparent)
-      Object.send :remove_const, 'Parent'      if defined?(::Parent)
-      Object.send :remove_const, 'Child'       if defined?(::Child)
-      Object.send :remove_const, 'OtherChild'  if defined?(::OtherChild)
+      Object.send :remove_const, 'Grandparent'         if defined?(::Grandparent)
+      Object.send :remove_const, 'Parent'              if defined?(::Parent)
+      Object.send :remove_const, 'Child'               if defined?(::Child)
+      Object.send :remove_const, 'OtherChild'          if defined?(::OtherChild)
+      Object.send :remove_const, 'EDocWithAValidation' if defined?(::EDocWithAValidation)
+      Object.send :remove_const, 'DocWithAValidation'  if defined?(::DocWithAValidation)
     end
 
     context "Including MongoMapper::EmbeddedDocument in a class" do
@@ -634,6 +647,29 @@ class EmbeddedDocumentTest < Test::Unit::TestCase
           @doc.options['baz'].should == 'wick'
         end
       end
+      
+      context "#save!" do
+         setup do
+           @root = DocWithAValidation.create(:name => "Root")
+           @doc = @root.e_doc_with_a_validations.build :name => "Embedded"
+         end
+         
+         should "should save when valid" do
+           @doc.save!
+           @root.reload.e_doc_with_a_validations.first.should == @doc
+         end
+         
+         should "should raise errors when invalid" do
+           @doc.name = ''
+           lambda{ @doc.save! }.should raise_error(MongoMapper::DocumentNotValid, "Validation failed: Name can't be empty")
+         end
+         
+         should "should raise errors when root document is invalid" do
+           @root.name = ''
+           @root.save(:validate => false)
+           lambda{ @doc.save! }.should raise_error(MongoMapper::DocumentNotValid, "Foo")
+         end
+       end
     end # instance of a embedded document
   end
 end


### PR DESCRIPTION
# save! should definitely not quietly succeed on invalid records.  Looking through the code this seemed like the most idiomatic approach, though we did consider adding valid! to wrap up the functionality of the valid? || raise logic.

Tests included, of course.
