### PR TITLE
Prevent belongs_to associations from being reloaded

### DIFF
--- a/lib/mongo_mapper/plugins/associations/belongs_to_polymorphic_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/belongs_to_polymorphic_proxy.rb
@@ -12,6 +12,11 @@ module MongoMapper
           proxy_owner[association.foreign_key] = id
           proxy_owner[association.type_key_name] = type
           reset
+          unless doc.nil?
+            loaded
+            @target = doc
+          end
+          @target
         end
 
         protected

--- a/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
@@ -9,8 +9,13 @@ module MongoMapper
             id = doc.id
           end
 
+          reset
           proxy_owner[association.foreign_key] = id
-          reload
+          unless doc.nil?
+            loaded
+            @target = doc
+          end
+          @target
         end
 
         protected

--- a/test/functional/associations/test_belongs_to_proxy.rb
+++ b/test/functional/associations/test_belongs_to_proxy.rb
@@ -49,6 +49,12 @@ class BelongsToProxyTest < Test::Unit::TestCase
     comment.post.should == post
     comment.post.nil?.should be_false
   end
+  
+  should "not reload the association when replacing" do
+    post = @post_class.new(:name => 'mongomapper')
+    comment = @comment_class.new(:name => 'Foo!', :post => post)
+    comment.post.proxy_target.object_id.should == post.object_id
+  end
 
   should "generate a new proxy when replacing the association" do
     post1 = @post_class.create(:name => 'post1')


### PR DESCRIPTION
As far as I can tell, `BelongsTo#replace` uses `reload` as a lazy reset/load_target; this works well enough, but it a) hits the database again, and b) breaks operations own the owner instance. For example:

```
 class Comment
  belongs_to :post

  after_save :increment_post_comment_count

  private

  def increment_post_comment_count
    post.increment(:comments_count => 1)
    post.comments_count += 1
  end
end

class Post
  key :comments_count, Integer, :default => 0
end

post = Post.new
comment.create(:post => post, :comment => "Hi there!")
post.comments_count # => 0
post.object_id == comment.post.proxy_target.object_id # => false
```

After this patch, `comment.post.proxy_target` should return the instance of `Post` that was originally assigned, making things like counter caches work nicely with views without having to do a bunch of messy reloads all over the place.

The same concept is applied to BelongsToPolymorphicProxy, as well.
