### PR TITLE
Rails2 branch support for replication set connections

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -3,6 +3,8 @@ require 'uri'
 
 module MongoMapper
   module Connection
+    @@use_replset = false
+
     # @api public
     def connection
       if @@use_replset
@@ -15,6 +17,7 @@ module MongoMapper
     # @api public
     def connection=(new_connection)
       @@connection = new_connection
+      @@use_replset = true if new_connection.kind_of? Mongo::ReplSetConnection
     end
 
     # @api public


### PR DESCRIPTION
I added basic support for replication sets (an important fault tolerance and load-balancing feature in MongoDB 1.6.x) via the Mongo::ReplSetConnection special connection object.  It is a replication set aware connection that learns about the set and can fail over to other nodes if one goes down as well as distribute the read load.

This is going to be very important to people using MongoDB in production environments.  It will require at least version 1.2 of the mongo gem (which, I think) is when ReplSetConnection came into being.

This was tested (briefly) under both Mongrel and Passenger (nginx).
