### PR TITLE
Ensure that documents initialized from database have valid _id

### DIFF
--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -171,6 +171,7 @@ module MongoMapper
         def initialize_from_database(attrs={})
           @_new = false
           load_from_database(attrs)
+          default_id_value(attrs)
           self
         end
 

--- a/test/functional/associations/test_many_embedded_proxy.rb
+++ b/test/functional/associations/test_many_embedded_proxy.rb
@@ -83,8 +83,10 @@ class ManyEmbeddedProxyTest < Test::Unit::TestCase
 
     owner = @owner_class.new(person_attributes)
     owner.name.should == 'Mr. Pet Lover'
+    owner.pets[0].id.class.should == BSON::ObjectId
     owner.pets[0].name.should == 'Jimmy'
     owner.pets[0].species.should == 'Cocker Spainel'
+    owner.pets[1].id.class.should == BSON::ObjectId
     owner.pets[1].name.should == 'Sasha'
     owner.pets[1].species.should == 'Siberian Husky'
 
@@ -92,8 +94,10 @@ class ManyEmbeddedProxyTest < Test::Unit::TestCase
     owner.reload
 
     owner.name.should == 'Mr. Pet Lover'
+    owner.pets[0].id.class.should == BSON::ObjectId
     owner.pets[0].name.should == 'Jimmy'
     owner.pets[0].species.should == 'Cocker Spainel'
+    owner.pets[1].id.class.should == BSON::ObjectId
     owner.pets[1].name.should == 'Sasha'
     owner.pets[1].species.should == 'Siberian Husky'
   end


### PR DESCRIPTION
The commit SHA abf216813a5f1d0f13c87fb2aaa092e71053e116 from August 29, 2010 1:04 PM with the comment "Using allocate to create new instance from database. Separated initialize and initialize_from_database instead of having two parameters for initialize. Should make overriding initialize/etc easier." changed the behavior of assigning many embedded documents using a hash. Previously, when doing this, the new embedded documents would correctly be assigned an _id. After this commit, the embedded documents would not get an _id.

I've updated MongoMapper::Plugins::Keys#initialize_from_database to ensure that the new document always has a valid _id attribute.

I've updated the "allow assignment of many embedded documents using a hash" test in ManyEmbeddedProxyTest to verify that the new documents have an _id of class BSON::ObjectId.
