### PR TITLE
Docs for Polymorphic Associations 

### DIFF
--- a/documentation/plugins/associations.textile
+++ b/documentation/plugins/associations.textile
@@ -159,7 +159,7 @@ Though you can't have polymorphism on the @belongs_to@ side with the "basic meth
 {% highlight ruby %}
 class Site
   include MongoMapper::Document
-  many :pages, :polymorphic => true
+  many :pages
 end
 
 class Page


### PR DESCRIPTION
I opted to keep a lot of the examples from the old docs to maintain a complete coverage of working cases (with cruft removed and renaming to make the examples more practical). Hopefully it's not too much--I just know it took me a long time to wrap my head around what polymorphism works where so having a complete set of examples should help others.

Update:
- removed :polymorphic => true from belongs_to example (can't remember why I had it there before)
