### PR TITLE
Inheritable attributes have been deprecated, replaced with the new class_attribute

### DIFF
--- a/lib/mongo_mapper/plugins/accessible.rb
+++ b/lib/mongo_mapper/plugins/accessible.rb
@@ -3,10 +3,14 @@ module MongoMapper
     module Accessible
       extend ActiveSupport::Concern
 
+      included do
+        class_attribute :_attr_accessible
+      end
+
       module ClassMethods
         def attr_accessible(*attrs)
           raise AccessibleOrProtected.new(name) if try(:protected_attributes?)
-          self.write_inheritable_attribute(:attr_accessible, Set.new(attrs) + (accessible_attributes || []))
+          self._attr_accessible = Set.new(attrs) + (accessible_attributes || [])
         end
 
         def accessible_attributes?
@@ -14,7 +18,7 @@ module MongoMapper
         end
 
         def accessible_attributes
-          self.read_inheritable_attribute(:attr_accessible)
+          self._attr_accessible
         end
       end
 

--- a/lib/mongo_mapper/plugins/protected.rb
+++ b/lib/mongo_mapper/plugins/protected.rb
@@ -6,14 +6,18 @@ module MongoMapper
     module Protected
       extend ActiveSupport::Concern
 
+      included do
+        class_attribute :_attr_protected
+      end
+
       module ClassMethods
         def attr_protected(*attrs)
           raise AccessibleOrProtected.new(name) if try(:accessible_attributes?)
-          self.write_inheritable_attribute(:attr_protected, Set.new(attrs) + (protected_attributes || []))
+          self._attr_protected = Set.new(attrs) + (protected_attributes || [])
         end
 
         def protected_attributes
-          self.read_inheritable_attribute(:attr_protected)
+          self._attr_protected
         end
 
         def protected_attributes?

--- a/lib/mongo_mapper/plugins/scopes.rb
+++ b/lib/mongo_mapper/plugins/scopes.rb
@@ -4,6 +4,10 @@ module MongoMapper
     module Scopes
       extend ActiveSupport::Concern
 
+      included do
+        class_attribute :_scopes
+      end
+
       module ClassMethods
         def scope(name, scope_options={})
           scopes[name] = lambda do |*args|
@@ -15,7 +19,7 @@ module MongoMapper
         end
 
         def scopes
-          read_inheritable_attribute(:scopes) || write_inheritable_attribute(:scopes, {})
+          self._scopes || self._scopes = {}
         end
       end
     end


### PR DESCRIPTION
While using MongoMapper on Rails 3.1.0.beta / Edge, you get the following deprecation warning:

```
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead.
```

This pull request replaces all inheritable attribute usage with the new class_attribute method and clears the deprecation warning.
