### PR TITLE
Prevent against another gem defining Boolean first as a Module and not a Class preventing MongoMapper from loading.

### DIFF
--- a/lib/mongo_mapper/extensions/boolean.rb
+++ b/lib/mongo_mapper/extensions/boolean.rb
@@ -39,6 +39,10 @@ module MongoMapper
   end
 end
 
-class Boolean
+unless defined?(::Boolean)
+  class ::Boolean; end
+end
+
+::Boolean.module_eval do 
   extend MongoMapper::Extensions::Boolean
 end


### PR DESCRIPTION
If you're using another gem in a rails app that defined Boolean first as a Module and not a Class, MongoMapper will fail to load when it attempts to extend the module.

Rather, use module_eval to include the methods into Boolean.

To reproduce, load the Ripple gem prior to MongoMapper in a Rails app.
