### PR TITLE
SystemTimer gem should only required in 1.8. Raises error in 1.9.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 group(:development) do
   gem 'bson_ext', '~> 1.3.0'
-  gem 'SystemTimer'
+  gem 'SystemTimer', :platform => :ruby_18
   gem 'ruby-debug', :platform => :ruby_18
   gem 'ruby-debug19', :platform => :ruby_19, :require => 'ruby-debug'
 


### PR DESCRIPTION
The SystemTimer gem fixes a problem in Ruby 1.8. The gem author says it's no longer required in Ruby 1.9 and in fact it raises an error if you try to install it in a 1.9 environment.
