### PR TITLE
Added tests: Document/EmbeddedDocument Instance methods should be able to read default value of key before type cast with read_attribute_before_type_cast 

### DIFF
--- a/lib/mongo_mapper/plugins/rails.rb
+++ b/lib/mongo_mapper/plugins/rails.rb
@@ -46,10 +46,6 @@ module MongoMapper
         def column_names
           keys.keys
         end
-
-        def human_name
-          self.name.demodulize.titleize
-        end
       end
     end
   end

--- a/test/unit/test_rails.rb
+++ b/test/unit/test_rails.rb
@@ -21,8 +21,8 @@ class TestRails < Test::Unit::TestCase
         @klass.column_names.sort.should == ['_id', 'foo']
       end
 
-      should "implement human_name" do
-        @klass.human_name.should == 'Post'
+      should "implement model_name.human" do
+        @klass.model_name.human.should == 'Post'
       end
     end
 
@@ -113,8 +113,8 @@ class TestRails < Test::Unit::TestCase
         @klass.column_names.sort.should == ['_id', 'foo']
       end
 
-      should "implement human_name" do
-        @klass.human_name.should == 'Post'
+      should "implement model_name.human" do
+        @klass.model_name.human.should == 'Post'
       end
     end
 

--- a/test/unit/test_rails_compatibility.rb
+++ b/test/unit/test_rails_compatibility.rb
@@ -39,14 +39,14 @@ class TestRailsCompatibility < Test::Unit::TestCase
       instance.new_record?.should == instance.new?
     end
 
-    should "implement human_name" do
-      Item.human_name.should == 'Item'
+    should "implement model_name.human" do
+      Item.model_name.human.should == 'Item'
     end
   end
 
   context "Document" do
-    should "implement human_name" do
-      BigStuff.human_name.should == 'Big Stuff'
+    should "implement model_name.human" do
+      BigStuff.model_name.human.should == 'Big stuff'
     end
   end
 end

--- a/test/unit/test_translation.rb
+++ b/test/unit/test_translation.rb
@@ -9,19 +9,27 @@ class TranslationTest < Test::Unit::TestCase
     Doc().i18n_scope.should == :mongo_mapper
   end
 
-  should "translate document attributes" do
-    I18n.config.backend.store_translations(:en, :mongo_mapper => {:attributes => {:thing => {:foo => 'Bar'}}})
-    doc = Doc('Thing') do
+  should "translate document model name and attributes" do
+    I18n.config.backend.store_translations(:en, :mongo_mapper => {
+      :models     => {:foo => 'Bar'},
+      :attributes => {:foo => {:foo => 'Bar'}}
+    })
+    doc = Doc('Foo') do
       key :foo, String
     end
+    doc.model_name.human.should == 'Bar'
     doc.human_attribute_name(:foo).should == 'Bar'
   end
 
-  should "translate embedded document attributes" do
-    I18n.config.backend.store_translations(:en, :mongo_mapper => {:attributes => {:thing => {:foo => 'Bar'}}})
-    doc = EDoc('Thing') do
+  should "translate embedded document model name and attributes" do
+    I18n.config.backend.store_translations(:en, :mongo_mapper => {
+      :models     => {:foo => 'Bar'},
+      :attributes => {:foo => {:foo => 'Bar'}}
+    })
+    doc = EDoc('Foo') do
       key :foo, String
     end
+    doc.model_name.human.should == 'Bar'
     doc.human_attribute_name(:foo).should == 'Bar'
   end
 end


### PR DESCRIPTION
Hello, guys!

I have problem with default value for keys.

Suppose we have:
-  Model:

``` ruby
class Domain
  include MongoMapper::Document

  key :name, String, :default => 'test.com'

end
```
-  Controller with action:

``` ruby
  def new
    @domain = Domain.new

    respond_to do |format|
      format.html # new.html.erb
      format.xml  { render :xml => @domain }
    end
  end
```
-  View with form:

``` rhtml
<%= form_for @domain do |f| %>

  <%= f.label :name %>:
  <%= f.text_field :name %><br />

  <%= f.submit %>

<% end %>
```

Currently text_field will not generate default value in input field.

How I understand (from AR behavior) _**_before_type_cast_\* methods should return default value for keys:

**SQLite 3** example:

``` ruby
domain = Domain.new # => #<Domain id: nil, name: "test.com", ...> 
domain.name_before_type_cast # => "test.com" 
domain.read_attribute_before_type_cast 'name' # => "test.com" 

# but (not sure that next code should work like above):
domain.read_attribute_before_type_cast :name # => nil 
```

**MongoMapper** example:

``` ruby
domain = Domain.new # => #<Domain _id: BSON::ObjectId('...'), name: "test.com">
domain.name_before_type_cast # => nil
domain.read_attribute_before_type_cast 'name' # => nil

domain.read_attribute_before_type_cast :name # => nil
```

I have added small tests that (I hope) should help solve problem with default values

Could somebody help with this ?
