### PR TITLE
#to_json broken on queries

### DIFF
--- a/lib/mongo_mapper/plugins/querying/decorator.rb
+++ b/lib/mongo_mapper/plugins/querying/decorator.rb
@@ -21,6 +21,10 @@ module MongoMapper
           end
         end
 
+        def as_json(options = nil)
+          map { |doc| doc.as_json(options) }
+        end
+
         private
           def method_missing(method, *args, &block)
             return super unless model.respond_to?(method)


### PR DESCRIPTION
```
class Thing
  include MongoMapper::Document
  key :name, String, :required => true
  key :date, Time
end

>> Thing.create(:name => 'bob')
=> #<Thing _id: BSON::ObjectId('4dc0ce2136c17133b7000001'), date: nil, name: "bob">
>> Thing.where(:name => 'bob').to_json
NoMethodError: undefined method `encode_json' for #<Thing:0x101ac0790>
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activemodel-3.0.7/lib/active_model/attribute_methods.rb:367:in `method_missing'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:214:in `encode_json'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:214:in `map'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:214:in `encode_json'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:47:in `encode'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:77:in `check_for_circular_references'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:45:in `encode'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:30:in `encode'
    from /Users/brent/.rvm/gems/ruby-1.8.7-p334/gems/activesupport-3.0.7/lib/active_support/core_ext/object/to_json.rb:15:in `to_json'
    from (irb):9
```

I added a fixed `#as_json` implementation in a horrible place (in `Plugins::Querying::Decorator`), so take or leave the patch, but I needed it fixed, and it was literally too much work to fork Plucky, fix it there, fork MongoMapper, replace the Plucky dependency (which I don't know how to do when it's a gemspec dependency and I only have a Github fork and not a true gem) etc.
