### PR TITLE
Removed implementation of method human_name

### DIFF
--- a/lib/mongo_mapper/plugins/rails.rb
+++ b/lib/mongo_mapper/plugins/rails.rb
@@ -46,10 +46,6 @@ module MongoMapper
         def column_names
           keys.keys
         end
-
-        def human_name
-          self.name.demodulize.titleize
-        end
       end
     end
   end

--- a/test/unit/test_rails.rb
+++ b/test/unit/test_rails.rb
@@ -30,10 +30,6 @@ class TestRails < Test::Unit::TestCase
       should "have column names" do
         @klass.column_names.sort.should == ['_id', 'foo']
       end
-
-      should "implement human_name" do
-        @klass.human_name.should == 'Post'
-      end
     end
 
     context "Instance methods" do
@@ -116,10 +112,6 @@ class TestRails < Test::Unit::TestCase
 
       should "have column names" do
         @klass.column_names.sort.should == ['_id', 'foo']
-      end
-
-      should "implement human_name" do
-        @klass.human_name.should == 'Post'
       end
     end
 

--- a/test/unit/test_rails_compatibility.rb
+++ b/test/unit/test_rails_compatibility.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class TestRailsCompatibility < Test::Unit::TestCase
-  class BigStuff
-    include MongoMapper::Document
-  end
-
   class Item
     include MongoMapper::EmbeddedDocument
     key :for_all, String
@@ -37,16 +33,6 @@ class TestRailsCompatibility < Test::Unit::TestCase
     should "alias new to new_record?" do
       instance = Item.new
       instance.new_record?.should == instance.new?
-    end
-
-    should "implement human_name" do
-      Item.human_name.should == 'Item'
-    end
-  end
-
-  context "Document" do
-    should "implement human_name" do
-      BigStuff.human_name.should == 'Big Stuff'
     end
   end
 end


### PR DESCRIPTION
Hello!

Currently you don't need to have own method #human_name because this method exist in ActiveModel and is deprecated.

Please pull. Thanks!
