### PR TITLE
Symbol type

### DIFF
--- a/lib/mongo_mapper/extensions/symbol.rb
+++ b/lib/mongo_mapper/extensions/symbol.rb
@@ -1,0 +1,18 @@
+# encoding: UTF-8
+module MongoMapper
+  module Extensions
+    module Symbol
+      def to_mongo(value)
+        value.to_s
+      end
+
+      def from_mongo(value)
+        value.to_sym
+      end
+    end
+  end
+end
+
+class Symbol
+  extend MongoMapper::Extensions::Symbol
+end


### PR DESCRIPTION
I would like to have symbol types in my document, so I created this extension, which stores values as strings in mongodb, but return a symbol when from_mongo is called

don't know if you like it, probably not, since you haven't created it yourself
