### PR TITLE
ReplSet connection support

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -59,12 +59,13 @@ module MongoMapper
     end
 
     def connect(environment, options={})
-      raise 'Set config before connecting. MongoMapper.config = {...}' if config.blank?      
+      raise 'Set config before connecting. MongoMapper.config = {...}' if config.blank?
       env = config_for_environment(environment)
-      if env['hosts']
-        MongoMapper.connection = Mongo::ReplSetConnection.new(*env['hosts'])
+
+      MongoMapper.connection = if env['hosts']
+        Mongo::ReplSetConnection.new( *env['hosts'].push(options) )
       else
-        MongoMapper.connection = Mongo::Connection.new(env['host'], env['port'], options)        
+        Mongo::Connection.new(env['host'], env['port'], options)
       end
 
       MongoMapper.database = env['database']

--- a/test/unit/test_mongo_mapper.rb
+++ b/test/unit/test_mongo_mapper.rb
@@ -98,16 +98,17 @@ class MongoMapperTest < Test::Unit::TestCase
     end
 
     should "create a replica set connection if config contains multiple hosts" do
-      config = {
+      MongoMapper.config = {
         'development' => {
-          'hosts' => [ ['127.0.0.1', 27017], ['127.0.0.1', 27017] ],
+          'hosts' => [ ['127.0.0.1', 27017], ['localhost', 27017] ],
           'database' => 'test'
         }
       }
-      MongoMapper.config = config
 
-      MongoMapper.connect('development')
-      MongoMapper.connection.should be_instance_of(Mongo::ReplSetConnection)
+      Mongo::ReplSetConnection.expects(:new).with( ['127.0.0.1', 27017], ['localhost', 27017], {'read_secondary' => true} )
+      MongoMapper.expects(:database=).with('test')
+      Mongo::DB.any_instance.expects(:authenticate).never
+      MongoMapper.connect('development', 'read_secondary' => true)
     end
   end
 


### PR DESCRIPTION
This pull request adds supports the same config style as mongoid for creating replica sets:

``` ruby
    'development' => {
      'hosts' => [ ['127.0.0.1', 27017], ['localhost', 27017] ],
      'database' => 'test'
    }
```

Tests are included.
