### PR TITLE
Serializer bug introduced in 0.9.1

### DIFF
--- a/test/unit/serializers/test_xml_serializer.rb
+++ b/test/unit/serializers/test_xml_serializer.rb
@@ -145,6 +145,9 @@ class XmlSerializationTest < Test::Unit::TestCase
       assert_no_match %r{awesome}, xml
       assert_no_match %r{created-at}, xml
       assert_no_match %r{preferences}, xml
+
+      # Assert only one tag is created
+      xml.scan(/favorite-quote/).size.should == 2
     end
   end
 


### PR DESCRIPTION
Hey guys, I ran into this while working on integrating MongoMapper with Devise. Apparently when you pass the `:method` option to `to_xml` it will output 2 tags per method instead of just one. I'm not sure what the right fix is for this.
