### PR TITLE
Documents should extend ActiveModel::Naming instead of including it

### DIFF
--- a/lib/mongo_mapper/plugins/active_model.rb
+++ b/lib/mongo_mapper/plugins/active_model.rb
@@ -4,13 +4,13 @@ module MongoMapper
     module ActiveModel
       extend ActiveSupport::Concern
 
-      include ::ActiveModel::Naming
       include ::ActiveModel::Conversion
       include ::ActiveModel::Serialization
       include ::ActiveModel::Serializers::Xml
       include ::ActiveModel::Serializers::JSON
 
       included do
+        extend ::ActiveModel::Naming
         extend ::ActiveModel::Translation
       end
     end


### PR DESCRIPTION
Problem: `Post.model_name` does not exist. `Post.new.model_name` exists but crashes since `model_name` calls `name` (which should exist, if it's a class method). Note: AR instances delegate `model_name` to their class.

Further reference: https://github.com/rails/rails/blob/3-0-9/activemodel/lib/active_model/naming.rb#L50
