### PR TITLE
Option *dependent* should destroy/delete/nullify associated records before destroy

### DIFF
--- a/lib/mongo_mapper/plugins/associations/many_association.rb
+++ b/lib/mongo_mapper/plugins/associations/many_association.rb
@@ -44,7 +44,7 @@ module MongoMapper
           association = self
           options = self.options
 
-          model.after_destroy do
+          model.before_destroy do
             if !association.embeddable?
               case options[:dependent]
                 when :destroy

--- a/lib/mongo_mapper/plugins/associations/one_association.rb
+++ b/lib/mongo_mapper/plugins/associations/one_association.rb
@@ -24,7 +24,7 @@ module MongoMapper
           association = self
           options = self.options
 
-          model.after_destroy do
+          model.before_destroy do
             if !association.embeddable?
               proxy = self.get_proxy(association)
               


### PR DESCRIPTION
Hey guys,

I'm not sure why is used after_destroy now, but in active_record this option uses before_destroy.

Please have a look at:
- [has_one](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/has_one.rb#L38)
- [has_many](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/has_many.rb#L25)

All tests are passing for 1.8.7 and 1.9.2
