### PR TITLE
added test: changed? should be false if the same ObjectId was assigned in String format

### DIFF
--- a/test/functional/test_dirty.rb
+++ b/test/functional/test_dirty.rb
@@ -106,6 +106,15 @@ class DirtyTest < Test::Unit::TestCase
       doc = @document.new
       doc.value_changed?.should be_false
     end
+
+    should "be false if the same ObjectId was assigned in String format" do
+      @document.key :doc_id, ObjectId
+
+      doc = @document.create!(:doc_id => BSON::ObjectId.new)
+      doc.changed?.should be_false
+      doc.doc_id = doc.doc_id.to_s
+      doc.changed?.should be_false
+    end
   end
 
   context "changes" do


### PR DESCRIPTION
Hello guys,

What do you think about this test?

Looks like typecasting of keys should be done before marking key as changed...

Please help
