### PR TITLE
Allow configurations from mongo.yml to be passed to Mongo::Connection.new

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -60,7 +60,18 @@ module MongoMapper
 
     def connect(environment, options={})
       raise 'Set config before connecting. MongoMapper.config = {...}' if config.blank?
-      env = config_for_environment(environment)
+      full_config = config_for_environment(environment)
+
+      env = {
+        'hosts'    => full_config.delete('hosts'),
+        'host'     => full_config.delete('host'),
+        'port'     => full_config.delete('port'),
+        'database' => full_config.delete('database'),
+        'username' => full_config.delete('username'),
+        'password' => full_config.delete('password')
+      }
+
+      options = full_config.merge(options).symbolize_keys
 
       MongoMapper.connection = if env['hosts']
         Mongo::ReplSetConnection.new( *env['hosts'].push(options) )


### PR DESCRIPTION
My mongo.yml has the following lines:

```
development:
  host: 127.0.0.1
  database: my_proj_development
  pool_size: 10
```

Now, in `rails s`:

```
# Before this commit:
MongoMapper.connection.pool_size # => 1

# After this commit:
MongoMapper.connection.pool_size # => 10
```
