### PR TITLE
Changing Railtie to not call DescendantsTracker.clear; test for same

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ group(:development) do
   gem 'timecop',           '~> 0.3.1'
   gem 'mocha',             '~> 0.9.8'
   gem 'rack-test'
+  gem 'rails'
 end

--- a/lib/mongo_mapper/railtie.rb
+++ b/lib/mongo_mapper/railtie.rb
@@ -37,10 +37,9 @@ module MongoMapper
     initializer "mongo_mapper.prepare_dispatcher" do |app|
       # See http://groups.google.com/group/mongomapper/browse_thread/thread/68f62e8eda43b43a/4841dba76938290c
       # to_prepare is called before each request in development mode and the first request in production.
+
       ActionDispatch::Callbacks.to_prepare do
         unless app.config.cache_classes
-          # Rails reloading was making descendants fill up and leak memory, these make sure they get cleared
-          ActiveSupport::DescendantsTracker.clear
           MongoMapper::Plugins::IdentityMap.models.clear
         end
       end

--- a/test/support/railtie.rb
+++ b/test/support/railtie.rb
@@ -1,0 +1,4 @@
+module Railtie
+  # We could get AS::Dependencies to autocreate this module
+  # but let's keep it simple
+end

--- a/test/support/railtie/autoloaded.rb
+++ b/test/support/railtie/autoloaded.rb
@@ -1,0 +1,2 @@
+class Railtie::Autoloaded < Railtie::Parent
+end

--- a/test/support/railtie/not_autoloaded.rb
+++ b/test/support/railtie/not_autoloaded.rb
@@ -1,0 +1,3 @@
+class Railtie::NotAutoloaded < Railtie::Parent
+
+end

--- a/test/support/railtie/parent.rb
+++ b/test/support/railtie/parent.rb
@@ -1,0 +1,3 @@
+class Railtie::Parent
+  extend ActiveSupport::DescendantsTracker
+end

--- a/test/unit/test_railtie.rb
+++ b/test/unit/test_railtie.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+require "rails"
+require 'mongo_mapper/railtie'
+
+class TestRailtie < Test::Unit::TestCase
+
+  def expect_descendants expectation
+  # Keep expectation a string so we don't accidentally load in a class
+    Railtie::Parent.descendants.map(&:to_s).sort.should == expectation.sort
+  end
+
+  def run_initializer mod, name
+    initializer = mod.initializers.detect do |i|
+      i.name == name
+    end
+    initializer.block.arity == -1 ? initializer.run : initializer.run(FakeRails)
+    # mongo_mapper.prepare_dispatcher takes a Rails app as its one arg,
+    # set_clear_dependencies_hook takes no args
+  end
+
+  def load_autoloaded_class
+    Railtie::Autoloaded.presence
+  end
+
+
+  class FakeRails
+    def self.config
+      return Class.new { def cache_classes ; false ; end }.new
+    end
+  end
+
+  context "Railtie" do
+
+    include Rails::Application::Bootstrap
+
+    setup do
+      require 'support/railtie'
+      require 'support/railtie/parent'
+      require 'support/railtie/not_autoloaded'
+
+      ActiveSupport::Dependencies.autoload_paths << File.join(File.dirname(__FILE__), '..', 'support')
+
+    # These initializers don't actually run anything, they just register cleanup and prepare hooks
+      run_initializer Rails::Application::Bootstrap, :set_clear_dependencies_hook
+      run_initializer MongoMapper::Railtie, 'mongo_mapper.prepare_dispatcher'
+    end
+
+    should "NOT clear ActiveSupport::DescendantsTracker" do
+
+      expect_descendants %w( Railtie::NotAutoloaded )
+
+      load_autoloaded_class
+
+      expect_descendants %w( Railtie::NotAutoloaded Railtie::Autoloaded )
+
+      ActionDispatch::Reloader.cleanup!
+      # cleanup 'last request'
+
+      expect_descendants %w( Railtie::NotAutoloaded )
+
+      load_autoloaded_class
+
+      expect_descendants %w( Railtie::NotAutoloaded Railtie::Autoloaded )
+
+      ActionDispatch::Reloader.prepare!
+      # prepare 'next request'
+
+      expect_descendants %w( Railtie::NotAutoloaded Railtie::Autoloaded )
+    end
+  end
+end


### PR DESCRIPTION
This was a real bugger. But we now know a lot more about active_support, mongo_mapper, railties, thinking_sphinx, and rails bootstrapping. This was the best way we could find to describe this problem:

ThinkingSphinx
 1 looks for all the files in app/models
 2 deduces a constant name from the file names
 3 calls .constantize on the string from 2 to trigger ActiveSupport::Dependencies to go out and autoload that same file.
 4 iterates over AR::Base.descendants, looking for index definitions in each of the models

 MongoMapper
  Calls ActiveSupport::DescendantsTracker.clear, but not ActiveSupport::Dependencies.clear. This means that when TS gets to step 3, the constant is not in DescendantsTracker, but is in Dependencies. So, when TS references the constant, Dependencies sees that it's already loaded and does nothing, meaning the inherited hook on AR::Base isn't called, meaning that the class isn't reinserted into DescendantsTracker, meaning that TS can't find the indexes on that model. 

  Rails, as of at least 3.0.10 always calls BOTH ActiveSupport::DescendantsTracker.clear and ActiveSupport::Dependencies.clear in the cleanup hook for server requests. This is correct, and gets Dependencies to go ahead and reload the files thus cleared

  Long story short, calling one without the other creates a discrepency between the constants which have been loaded and the list of descendants. And there is no need for this call as Rails handles it for us.

Thanks,
Michael and Thomas
