### PR TITLE
Makes formtastic happy, it expects the macro method to return :has_many o

### DIFF
--- a/lib/mongo_mapper/plugins/associations/many_association.rb
+++ b/lib/mongo_mapper/plugins/associations/many_association.rb
@@ -11,6 +11,10 @@ module MongoMapper
         def type_key_name
           "_type"
         end
+        
+        def macro
+          :has_many
+        end
 
         # hate this, need to revisit
         def proxy_class


### PR DESCRIPTION
Makes formtastic happy, it expects the macro method to return :has_many or similar.

See http://rubydoc.info/docs/rails/3.0.0/ActiveRecord/Reflection/MacroReflection#macro-instance_method for what this emulates.

Also see https://github.com/justinfrench/formtastic/blob/master/lib/formtastic/helpers/reflection.rb line 17 for where this method is used.
