### PR TITLE
Use plucky 0.4.x, which supports $and queries. [Fixes #339]

### DIFF
--- a/lib/mongo_mapper/plugins/associations/in_array_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/in_array_proxy.rb
@@ -103,8 +103,8 @@ module MongoMapper
           def query(options={})
             klass.
               query(association.query_options).
-              update(options).
-              update(criteria)
+              amend(options).
+              amend(criteria)
           end
 
           def criteria

--- a/lib/mongo_mapper/plugins/associations/many_documents_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/many_documents_proxy.rb
@@ -74,7 +74,7 @@ module MongoMapper
           def query(options={})
             klass.
               query(association.query_options).
-              update(options).update(criteria)
+              amend(options).amend(criteria)
           end
 
           def method_missing(method, *args, &block)

--- a/lib/mongo_mapper/plugins/identity_map.rb
+++ b/lib/mongo_mapper/plugins/identity_map.rb
@@ -34,14 +34,14 @@ module MongoMapper
 
         module IdentityMapQueryMethods
           def all(opts={})
-            query = clone.update(opts)
+            query = clone.amend(opts)
             super.tap do |docs|
               model.remove_documents_from_map(docs) if query.fields?
             end
           end
 
           def find_one(opts={})
-            query = clone.update(opts)
+            query = clone.amend(opts)
 
             if model.identity_map_on? && query.simple? && model.identity_map[query[:_id]]
               model.identity_map[query[:_id]]

--- a/lib/mongo_mapper/plugins/querying.rb
+++ b/lib/mongo_mapper/plugins/querying.rb
@@ -64,7 +64,7 @@ module MongoMapper
           query = Plucky::Query.new(collection, :transformer => transformer)
           query.extend(Decorator)
           query.object_ids(object_id_keys)
-          query.update(options)
+          query.amend(options)
           query.model(self)
           query
         end
@@ -80,7 +80,7 @@ module MongoMapper
           end
 
           def find_some(ids, options={})
-            query = query(options).update(:_id => ids.flatten.compact.uniq)
+            query = query(options).amend(:_id => ids.flatten.compact.uniq)
             find_many(query.to_hash).compact
           end
 

--- a/mongo_mapper.gemspec
+++ b/mongo_mapper.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel',             '~> 3.0'
   s.add_dependency 'activesupport',           '~> 3.0'
-  s.add_dependency 'plucky',                  '~> 0.3.8'
+  s.add_dependency 'plucky',                  '~> 0.4.0'
 end


### PR DESCRIPTION
Use plucky 0.4.x, which supports $and queries.  No longer compatible with < 0.4, plucky changed Query#update to Query#amend.

Also, you may have to do some project Gemfile fighting to get mongo, bson, and bson_ext to line up (not helped by the recent yanking of bson 1.4.0 and 1.4.1).
