### PR TITLE
Fixed copy/paste errors in test

### DIFF
--- a/test/functional/test_modifiers.rb
+++ b/test/functional/test_modifiers.rb
@@ -156,7 +156,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(foo)
 
         @page2.reload
-        @page.tags.should == %w(foo)
+        @page2.tags.should == %w(foo)
       end
 
       should "work with ids and modifier hash" do
@@ -166,7 +166,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(foo)
 
         @page2.reload
-        @page.tags.should == %w(foo)
+        @page2.tags.should == %w(foo)
       end
     end
 
@@ -184,7 +184,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == @tags
 
         @page2.reload
-        @page.tags.should == @tags
+        @page2.tags.should == @tags
       end
 
       should "work with ids and modifier hash" do
@@ -194,7 +194,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == @tags
 
         @page2.reload
-        @page.tags.should == @tags
+        @page2.tags.should == @tags
       end
     end
 
@@ -211,7 +211,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(bar)
 
         @page2.reload
-        @page.tags.should == %w(bar)
+        @page2.tags.should == %w(bar)
       end
 
       should "be able to pull with ids and modifier hash" do
@@ -221,7 +221,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(bar)
 
         @page2.reload
-        @page.tags.should == %w(bar)
+        @page2.tags.should == %w(bar)
       end
     end
 
@@ -238,7 +238,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(baz)
 
         @page2.reload
-        @page.tags.should == %w(baz)
+        @page2.tags.should == %w(baz)
       end
 
       should "work with ids and modifier hash" do
@@ -248,7 +248,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(baz)
 
         @page2.reload
-        @page.tags.should == %w(baz)
+        @page2.tags.should == %w(baz)
       end
     end
 
@@ -265,7 +265,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(foo)
 
         @page2.reload
-        @page.tags.should == %w(foo)
+        @page2.tags.should == %w(foo)
       end
 
       should "be able to add to set with ids and modifier hash" do
@@ -275,7 +275,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(foo)
 
         @page2.reload
-        @page.tags.should == %w(foo)
+        @page2.tags.should == %w(foo)
       end
     end
 
@@ -292,7 +292,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(foo)
 
         @page2.reload
-        @page.tags.should == %w(foo)
+        @page2.tags.should == %w(foo)
       end
 
       should "be able to push uniq with ids and modifier hash" do
@@ -302,7 +302,7 @@ class ModifierTest < Test::Unit::TestCase
         @page.tags.should == %w(foo)
 
         @page2.reload
-        @page.tags.should == %w(foo)
+        @page2.tags.should == %w(foo)
       end
     end
 
@@ -404,7 +404,7 @@ class ModifierTest < Test::Unit::TestCase
       page.tags.should == %w(foo)
 
       page2.reload
-      page.tags.should == %w(foo)
+      page2.tags.should == %w(foo)
     end
 
     should "be able to push uniq with criteria and modifier hash" do
@@ -418,7 +418,7 @@ class ModifierTest < Test::Unit::TestCase
       page.tags.should == %w(foo)
 
       page2.reload
-      page.tags.should == %w(foo)
+      page2.tags.should == %w(foo)
     end
 
     should "be able to pop with modifier hashes" do


### PR DESCRIPTION
I was looking at this test in order to model tests for my new chainable modifiers code and found the following 

``` ruby
page.reload
page.tags.should == %w(foo)

page2.reload
page.tags.should == %w(foo)
```

That didn't look right to me, so I changed the last line to:

``` ruby
page2.tags.should == %w(foo)
```

I think the actual code works, the bug is just in the test.
