### PR TITLE
Key aliasing

### DIFF
--- a/examples/key_abbreviation.rb
+++ b/examples/key_abbreviation.rb
@@ -8,13 +8,13 @@ class Goat
   include MongoMapper::Document
   belongs_to :user
   
-  key :user_id, ObjectId, :alias => :g_id
+  key :user_id, ObjectId, :abbr => :g_id
 end
 
 class User
   include MongoMapper::Document
-  key :email_address, String, :alias => :e
-  key :hate_to_store_this_long_key_for_each_document, String, :alias => :'l'
+  key :email_address, String, :abbr => :e
+  key :hate_to_store_this_long_key_for_each_document, String, :abbr => :'l'
   
   many :goats, :class_name => 'Goat', :foreign_key => :g_id
 end
@@ -37,7 +37,7 @@ puts "raw mongo looks like:   #{MongoMapper.connection['testing']['users'].find(
 u2 = User.find_by_email_address('IHeartSmallDB@gmail.com')
 puts u2.inspect
 
-#alias are useful for associations, just need to set the foreign_key in the parent
+#abbreviations are useful for associations, just need to set the foreign_key in the parent
 u2.goats << Goat.new()
 u2.reload
 puts "the users goats: #{u2.goats.inspect}"

--- a/lib/mongo_mapper/plugins/keys/key.rb
+++ b/lib/mongo_mapper/plugins/keys/key.rb
@@ -3,18 +3,18 @@ module MongoMapper
   module Plugins
     module Keys
       class Key
-        attr_accessor :name, :type, :options, :default_value, :alias
+        attr_accessor :name, :type, :options, :default_value, :abbr
 
         def initialize(*args)
           options = args.extract_options!
           @name, @type = args.shift.to_s, args.shift
           self.options = (options || {}).symbolize_keys
           self.default_value = self.options[:default]
-          self.alias = self.options[:alias]
+          self.abbr = self.options[:abbr]
         end
 
         def ==(other)
-          @name == other.name && @type == other.type && @alias == other.alias
+          @name == other.name && @type == other.type && @abbr == other.abbr
         end
 
         def embeddable?

--- a/lib/mongo_mapper/plugins/querying/decorator.rb
+++ b/lib/mongo_mapper/plugins/querying/decorator.rb
@@ -23,14 +23,14 @@ module MongoMapper
         
         %w(first last all where find_each exist? exists? count).each do |meth|
           define_method(meth.to_sym) do |*args, &block|
-            rewrite_keys_with_aliases(args)
+            rewrite_keys_with_abbr(args)
             super(*args, &block)
           end
         end
         
         %w(fields sort).each do |meth|
           define_method(meth.to_sym) do |*args, &block|
-            args = rewrite_args_with_aliases(args)
+            args = rewrite_args_with_abbr(args)
             super(*args, &block)
           end
         end
@@ -43,32 +43,32 @@ module MongoMapper
             merge(result)
           end
                     
-          def rewrite_keys_with_aliases(args)
-            if args[0].is_a? Hash and model.respond_to? :alias_for_key_name
-              aliased_attrs = {}
+          def rewrite_keys_with_abbr(args)
+            if args[0].is_a? Hash and model.respond_to? :abbr_for_key_name
+              abbreviated_attrs = {}
               args[0].each do |k,v| 
                 if k.is_a? SymbolOperator
-                  aliased_attrs[SymbolOperator.new( model.alias_for_key_name(k.field.to_s).to_sym, k.operator )] = v
+                  abbreviated_attrs[SymbolOperator.new( model.abbr_for_key_name(k.field.to_s).to_sym, k.operator )] = v
                 else
-                  aliased_attrs[model.alias_for_key_name(k)] = v
+                  abbreviated_attrs[model.abbr_for_key_name(k)] = v
                 end
               end
-              args[0] = aliased_attrs
+              args[0] = abbreviated_attrs
             end
           end
           
-          def rewrite_args_with_aliases(args)
-            if args.is_a? Array and model.respond_to? :alias_for_key_name
-              aliased_args = []
+          def rewrite_args_with_abbr(args)
+            if args.is_a? Array and model.respond_to? :abbr_for_key_name
+              abbreviated_args = []
               args.each do |a|
                 if a.is_a? SymbolOperator
-                  aliased_args << SymbolOperator.new( model.alias_for_key_name(a.field.to_s).to_sym, a.operator )
+                  abbreviated_args << SymbolOperator.new( model.abbr_for_key_name(a.field.to_s).to_sym, a.operator )
                 else
-                  aliased_args << model.alias_for_key_name(a)
+                  abbreviated_args << model.abbr_for_key_name(a)
                 end
               end
             end
-            aliased_args
+            abbreviated_args
           end
       end
     end

--- a/test/functional/test_associations.rb
+++ b/test/functional/test_associations.rb
@@ -44,7 +44,7 @@ class AssociationsTest < Test::Unit::TestCase
     post1.tags.should == [tag1]
   end
   
-  should "interoperate with aliased keys" do
+  should "interoperate with abbreviated keys" do
     class AnotherUser
       include MongoMapper::Document
 
@@ -55,8 +55,8 @@ class AssociationsTest < Test::Unit::TestCase
     class AwesomeGoat
       include MongoMapper::Document
       
-      key :name, String, :alias => :n
-      key :user_id, ObjectId, :alias => :u_id
+      key :name, String, :abbr => :n
+      key :user_id, ObjectId, :abbr => :u_id
       
       belongs_to :user, :class_name => 'AssociationsTest::AnotherUser'
     end

--- a/test/functional/test_key_abbreviation.rb
+++ b/test/functional/test_key_abbreviation.rb
@@ -1,34 +1,34 @@
 require 'test_helper'
 require 'models'
 
-class AliasingTest < Test::Unit::TestCase
+class KeyAbbreviationTest < Test::Unit::TestCase
   def setup
     @document = Doc do
-      key :first_name, String, :alias => :f
-      key :last_name, String, :alias => :l
-      key :unaliased, String
-      key :age, Integer, :alias => :a
+      key :first_name, String, :abbr => :f
+      key :last_name, String, :abbr => :l
+      key :unabbreviated, String
+      key :age, Integer, :abbr => :a
     end
 
-    @doc = @document.create(:first_name => 'John',  :last_name => 'Nunemaker', :unaliased => "foo", :age => 27)
+    @doc = @document.create(:first_name => 'John',  :last_name => 'Nunemaker', :unabbreviated => "foo", :age => 27)
     @abe = @document.create(:first_name => 'Abe',  :last_name => 'Lincoln', :age => 200)
   end
   
-  context "basic i/o of aliased keys" do
-    should "store key aliases in db, not full keys" do
+  context "basic i/o of abbreviated keys" do
+    should "store key abbreviation in db, not full keys" do
       raw_object = MongoMapper.connection[@document.database.name][@document.collection.name].find({"_id" => @doc.id}).first
       raw_object.include?("first_name").should == false
       raw_object["f"].should == "John"
       raw_object.include?("last_name").should == false
       raw_object["l"].should == "Nunemaker"
-      raw_object["unaliased"].should == "foo"
+      raw_object["unabbreviated"].should == "foo"
     end
     
-    should "create model with long keys when loaded from aliases model in db" do
+    should "create model with long keys when loaded from abbreviated model in db" do
       @doc.reload
       @doc.first_name.should == "John"
       @doc.last_name.should == "Nunemaker"
-      @doc.unaliased.should == "foo"
+      @doc.unabbreviated.should == "foo"
     end
     
     should "serialize to_json with long keys" do
@@ -37,7 +37,7 @@ class AliasingTest < Test::Unit::TestCase
       assert_match %r{"first_name":"John"}, json
       assert_no_match %r{"l"}, json
       assert_match %r{"last_name":"Nunemaker"}, json
-      assert_match %r{"unaliased":"foo"}, json
+      assert_match %r{"unabbreviated":"foo"}, json
     end
     
     should "serialize to_xml with long keys" do
@@ -46,60 +46,60 @@ class AliasingTest < Test::Unit::TestCase
       assert_match %r{<first-name>John</first-name>}, xml
       assert_no_match %r{<l>}, xml
       assert_match %r{<last-name>Nunemaker</last-name>}, xml
-      assert_match %r{<unaliased>foo</unaliased>}, xml
+      assert_match %r{<unabbreviated>foo</unabbreviated>}, xml
     end
   end
   
   context "dynamic finders" do
-    should "accept query on long key and perform mongo query on alias" do
+    should "accept query on long key and perform mongo query on abbreviations" do
       d = @document.find_by_first_name('John')
       d.should == @doc
     end
     
-    should "accept query on multiple aliased keys" do
+    should "accept query on multiple abbreviated keys" do
       d = @document.find_by_first_name_and_last_name('John', 'Nunemaker')
       d.should == @doc
     end
     
-    should "accept query on aliased and non-aliased keys" do
-      d = @document.find_by_first_name_and_unaliased('John', 'foo')
+    should "accept query on abbreviated and non-abbreviated keys" do
+      d = @document.find_by_first_name_and_unabbreviated('John', 'foo')
       d.should == @doc
     end
     
-    should "find all on aliased key" do
+    should "find all on abbreviated key" do
       d = @document.find_all_by_first_name('John')
       d.size.should == 1
       d[0].should == @doc
     end
   end
   
-  context "querying with aliased keys" do
-    should "find first from aliased key" do
+  context "querying with abbreviated keys" do
+    should "find first from abbreviated key" do
       d = @document.first(:first_name => 'John')
       d.should == @doc
     end
     
-    should "find last from aliased key" do
+    should "find last from abbreviated key" do
       d = @document.last(:first_name => 'John')
       d.should == @doc
     end
     
-    should "count with aliased key" do
+    should "count with abbreviated key" do
       @document.count(:first_name => 'John').should == 1
     end
     
-    should "find all with aliased key" do
+    should "find all with abbreviated key" do
       d = @document.all(:first_name => 'John')
       d.size.should == 1
       d[0].should == @doc
     end
     
-    should "accept alias keys in where clause" do
+    should "accept abbreviated keys in where clause" do
       d = @document.where(:first_name => 'John').first
       d.should == @doc
     end
     
-    should "accept alias keys in where clause with symbol operators" do
+    should "accept abbreviated keys in where clause with symbol operators" do
       d = @document.where(:age.gt => 100).first
       d.should == @abe
       
@@ -107,47 +107,47 @@ class AliasingTest < Test::Unit::TestCase
       d2.should == @doc
     end
     
-    should "accept key alias sorting w/ with symbol operators" do
+    should "accept key abbreviation sorting w/ with symbol operators" do
       @document.sort(:last_name.asc).first.should == @abe
       @document.sort(:last_name.desc).first.should == @doc
     end
     
-    should "accept key alias in exist?" do
+    should "accept key abbreviation with exist?" do
       @document.exist?(:first_name => 'John').should == true
     end
     
-    should "accept key alias in exists?" do
+    should "accept key abbreviation with exists?" do
       @document.exists?(:first_name => 'John').should == true
     end
     
-    should "accept key alias when selecting fields" do
-      d = @document.where(:first_name => 'John').fields(:last_name, :unaliased).first
+    should "accept key abbreviations when selecting fields" do
+      d = @document.where(:first_name => 'John').fields(:last_name, :unabbreviated).first
       d.first_name.should == nil
       d.last_name.should == 'Nunemaker'
-      d.unaliased.should == 'foo'
+      d.unabbreviated.should == 'foo'
     end
     
-    should "accept key alias for normal sort operations" do
+    should "accept key abbreviation for normal sort operations" do
       d = @document.sort(:last_name).first
       d.should == @abe
     end
     
-    should "accept key alias for sort operations with symbol operators" do
+    should "accept key abbreviation for sort operations with symbol operators" do
       d = @document.sort(:age.asc).first
       d.should == @doc
     end
     
-    should "accept mongo conditional operators on aliased keys" do
+    should "accept mongo conditional operators on abbreviated keys" do
       d = @document.where(:age => {:$gt => 100, :$lt => 500}).first
       d.should == @abe
     end
     
-    should "be able to string together query parts, all using aliases" do
+    should "be able to string together query parts, all using abbreviations" do
       @document.sort(:age).where(:first_name => 'John').count(:last_name => 'Nunemaker').should == 1
-      @document.sort(:age).where(:first_name => 'John').where(:last_name => 'Nunemaker').first(:unaliased => "foo").should == @doc
+      @document.sort(:age).where(:first_name => 'John').where(:last_name => 'Nunemaker').first(:unabbreviated => "foo").should == @doc
     end
     
-    should "be able to find each using aliased query" do
+    should "be able to find each using abbreviated keys in query" do
       count = 0
       @document.find_each(:age.gt => 1) do |d|
         count += 1

--- a/test/models.rb
+++ b/test/models.rb
@@ -56,7 +56,7 @@ end
 class Address
   include MongoMapper::EmbeddedDocument
 
-  key :address, String, :alias => :a
+  key :address, String, :abbr => :a
   key :city,    String
   key :state,   String
   key :zip,     Integer

--- a/test/unit/test_key.rb
+++ b/test/unit/test_key.rb
@@ -27,8 +27,8 @@ class KeyTest < Test::Unit::TestCase
       Key.new(:foo, Integer, :required => true).options[:required].should be(true)
     end
     
-    should "allow setting alias" do
-      Key.new(:foo, Integer, :alias => :f).options[:alias].should be(:f)
+    should "allow setting abbr" do
+      Key.new(:foo, Integer, :abbr => :f).options[:abbr].should be(:f)
     end
 
     should "default options to {}" do
@@ -69,8 +69,8 @@ class KeyTest < Test::Unit::TestCase
       Key.new(:name, String).should == Key.new(:name, String)
     end
     
-    should "be equal to another key with same name, type, and alias" do
-      Key.new(:name, String, :alias => :n).should == Key.new(:name, String, :alias => :n)
+    should "be equal to another key with same name, type, and abbr" do
+      Key.new(:name, String, :abbr => :n).should == Key.new(:name, String, :abbr => :n)
     end
 
     should "not be equal to another key with different name" do
@@ -81,8 +81,8 @@ class KeyTest < Test::Unit::TestCase
       Key.new(:name, String).should_not == Key.new(:name, Integer)
     end
 
-    should "not be equal to another key with different alias" do
-      Key.new(:name, :alias => :n).should_not == Key.new(:name, :alias => :x)
+    should "not be equal to another key with different abbr" do
+      Key.new(:name, :abbr => :n).should_not == Key.new(:name, :abbr => :x)
     end
 
     should "know if it is a embedded_document" do


### PR DESCRIPTION
...because Mongo stores the entire key with each document, and that's terrible with large datasets.

This patch allows you to add the :alias option to any key which will define what string is actually stored in Mongo as the key.  This is done transparently, so your code can continue to use the human-readable long key while persisting in mongo with the (presumably shorter) alias.

For example:

``` ruby
class User
  include MongoMapper::Document
  key :email_address, String, :alias => :e
end

u = User.find_by_email_address("spinosa@gmail.com")
u.email_address = "dan@shelby.tv" 
u.save

#user in db looks like {_id: 'NormalObjectId', e: 'dan@shelby.tv' }
```

I fully expect, understand and would appreciate feedback on this pull request; I look forward to improving this topic branch.  

Thanks for taking the time to look it over.
