### PR TITLE
validates_associated context limitations

### DIFF
--- a/lib/mongo_mapper/plugins/validations.rb
+++ b/lib/mongo_mapper/plugins/validations.rb
@@ -68,7 +68,7 @@ module MongoMapper
 
       class AssociatedValidator < ::ActiveModel::EachValidator
         def validate_each(record, attribute, value)
-          if !Array.wrap(value).all? { |c| c.nil? || c.valid? }
+          if !Array.wrap(value).all? { |c| c.nil? || c.valid?(options[:context]) }
             record.errors.add(attribute, :invalid, :message => options[:message], :value => value)
           end
         end

--- a/test/functional/test_validations.rb
+++ b/test/functional/test_validations.rb
@@ -350,6 +350,39 @@ class ValidationsTest < Test::Unit::TestCase
       doc.children.build
       doc.should have_error_on(:children, 'are invalid')
     end
+
+  end
+
+  context "validating associated docs with custom context" do
+    setup do
+      @child_class = EDoc do
+        key :name
+
+        validates_length_of :name, :minimum => 5, :on => :custom_context
+      end
+
+      @root_class = Doc { }
+      @root_class.many :children, :class => @child_class
+      @root_class.validates_associated :children, :context => :custom_context
+    end
+
+    should "pass if there are no associated docs" do
+      doc = @root_class.new
+      doc.valid?(:custom_context).should be_true
+    end
+
+    should "pass if the associated doc is valid" do
+      doc = @root_class.new
+      doc.children.build(:name => 'George')
+      doc.valid?(:custom_context).should be_true
+    end
+
+    should "fail if the associated doc is invalid" do
+      doc = @root_class.new
+      doc.children.build(:name => 'Bob')
+      doc.valid?(:custom_context).should_not be_true
+    end
+
   end
   # context "validates uniqueness of with :unique shortcut" do
   #   should "work" do


### PR DESCRIPTION
Currently, `validates_associated` always validates against a nil context when invoking the association's `valid?` method. This is a limitation if you want to validate the association is a different context.

Always passing through the context from the root's `valid?(context)` would wind up with `:create` and `:update` getting passed to the association. That has the possibility of strange behavior (ie. when the association is new and the root is not).

Instead, a possible solution is to allow a `:context` option to be set on the `validates_associated` call.

```
validates_associated :user, :context => :vip
```

While this doesn't have the flexibility of allowing a per-`valid?` call context, it at least provides a way to use an alternative validation context on associations.
