### PR TITLE
Make update_attribute behave like in ActiveRecord

### DIFF
--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -223,7 +223,9 @@ module MongoMapper
         end
 
         def update_attribute(name, value)
-          update_attributes(name.to_sym => value)
+          name = name.to_s
+          self.send(:"#{name}=", value)
+          save(:validate => false)
         end
 
         def id

--- a/test/functional/test_accessible.rb
+++ b/test/functional/test_accessible.rb
@@ -68,6 +68,11 @@ class AccessibleTest < Test::Unit::TestCase
       doc.name.should == 'John'
     end
 
+    should "ignore inaccessible attribute on #update_attribute" do
+      @doc.update_attribute('admin', true)
+      @doc.admin.should be_false
+    end
+
     should "ignore inaccessible attribute on #update_attributes" do
       @doc.update_attributes(:name => 'Ren Hoek', :admin => true)
       @doc.name.should == 'Ren Hoek'

--- a/test/functional/test_embedded_document.rb
+++ b/test/functional/test_embedded_document.rb
@@ -241,6 +241,18 @@ class EmbeddedDocumentTest < Test::Unit::TestCase
     person.pets.first.crazy_key.should == 'crazy'
   end
 
+  should "be able to update_attribute" do
+    pet = @pet_klass.new(:name => 'sparky')
+    person = @klass.create(:pets => [pet])
+    person.reload
+    pet = person.pets.first
+
+    pet.update_attribute('name', 'koda').should be_true
+    person.reload
+    person.pets.first._id.should == pet._id
+    person.pets.first.name.should == 'koda'
+  end
+
   should "be able to update_attributes" do
     pet = @pet_klass.new(:name => 'sparky')
     person = @klass.create(:pets => [pet])

--- a/test/functional/test_protected.rb
+++ b/test/functional/test_protected.rb
@@ -74,6 +74,11 @@ class ProtectedTest < Test::Unit::TestCase
       doc.name.should == 'John'
     end
 
+    should "ignore protected attribute on #update_attribute" do
+      @doc.update_attribute('admin', true)
+      @doc.admin.should be_false
+    end
+
     should "ignore protected attribute on #update_attributes" do
       @doc.update_attributes(:name => 'Ren Hoek', :admin => true)
       @doc.name.should == 'Ren Hoek'
@@ -174,6 +179,11 @@ class ProtectedTest < Test::Unit::TestCase
     should "assign protected attribute through accessor" do
       @edoc.admin = true
       @edoc.admin.should be_true
+    end
+
+    should "ignore protected attribute on #update_attribute" do
+      @edoc.update_attribute('admin', true)
+      @edoc.admin.should be_false
     end
 
     should "ignore protected attribute on #update_attributes" do

--- a/test/functional/test_querying.rb
+++ b/test/functional/test_querying.rb
@@ -682,9 +682,28 @@ class QueryingTesting < Test::Unit::TestCase
       @doc = @document.create(:first_name => 'John', :age => '27')
     end
 
-    should "update the attribute" do
+    should "accept symbols as keys" do
       @doc.update_attribute(:first_name, 'Chris').should be_true
       @doc.reload.first_name.should == 'Chris'
+    end
+
+    should "update the attribute" do
+      @doc.update_attribute('first_name', 'Chris').should be_true
+      @doc.reload.first_name.should == 'Chris'
+    end
+
+    should "update the attribute without invoking validations" do
+      setup do
+        @document = Doc do
+          key :name, String, :required => true
+        end
+      end
+
+      doc = @document.new
+      doc.expects(:valid?).never
+      doc.update_attribute('name', '').should be_true
+      doc.reload.name.should == ''
+      @document.count.should == 1
     end
   end
 


### PR DESCRIPTION
As discussed in https://github.com/jnunemaker/mongomapper/issues/365 it should now save with validations disabled. Verified to work.

I added some tests, but please note I wasn't able to get the MongoMapper test suite to run on my system due to some gem issues, so I suggest verifying the tests before merging.

Cheers
