### PR TITLE
Use MongoDB connection options from yaml config file

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -62,8 +62,8 @@ module MongoMapper
       raise 'Set config before connecting. MongoMapper.config = {...}' if config.blank?
       env = config_for_environment(environment)
 
-      if env['connection_options'].is_a? Hash
-        options = env['connection_options'].symbolize_keys.merge(options)
+      if env['options'].is_a? Hash
+        options = env['options'].symbolize_keys.merge(options)
       end
 
       MongoMapper.connection = if env['hosts']

--- a/test/unit/test_mongo_mapper.rb
+++ b/test/unit/test_mongo_mapper.rb
@@ -65,6 +65,15 @@ class MongoMapperTest < Test::Unit::TestCase
       MongoMapper.connect('development', :logger => logger)
     end
 
+    should "work with options from config" do
+      MongoMapper.config = {
+        'development' => {'host' => '192.168.1.1', 'port' => 2222, 'database' => 'test', 'options' => {'safe' => true}}
+      }
+      connection, logger = mock('connection'), mock('logger')
+      Mongo::Connection.expects(:new).with('192.168.1.1', 2222, :logger => logger, :safe => true)
+      MongoMapper.connect('development', :logger => logger)
+    end
+
     should "work with options using uri" do
       MongoMapper.config = {
         'development' => {'uri' => 'mongodb://127.0.0.1:27017/test'}


### PR DESCRIPTION
The [constructor for `Mongo::Connection`](http://api.mongodb.org/ruby/current/Mongo/Connection.html#initialize-instance_method) takes several options. Currently, there is no way to configure these options in MongoMapper's YAML config file. This simple patch allows the connection options to be configured via the YAML config file like:

```
defaults: &defaults
  host: 127.0.0.1
  port: 27017
  connection_options:
    safe: true
    # etc...
```

As usual, I'm open to feedback so let me know if you'd like anything done differently. Thanks!
