### PR TITLE
Ability to handle save! validation errors programmatically

### DIFF
--- a/lib/mongo_mapper/exceptions.rb
+++ b/lib/mongo_mapper/exceptions.rb
@@ -14,7 +14,10 @@ module MongoMapper
 
   # raised when document not valid and using !
   class DocumentNotValid < Error
+    attr_reader :document
+  
     def initialize(document)
+      @document = document
       super("Validation failed: #{document.errors.full_messages.join(", ")}")
     end
   end


### PR DESCRIPTION
Currently, using save! is unusable in the case that you want to be able programmatically handle specific validation errors. My proposed change also matches the way activerecord handles save! validation errors -- see docs for the equivalent class in active record here: http://api.rubyonrails.org/classes/ActiveRecord/RecordInvalid.html
