### PR TITLE
Added note about Rails 3.2

### DIFF
--- a/documentation/getting-started/rails.textile
+++ b/documentation/getting-started/rails.textile
@@ -28,6 +28,29 @@ require "rails/test_unit/railtie"
 # require "sprockets/railtie"
 {% endhighlight %}
 
+For Rails 3.2 you also need to disable next code in files:
+
+* @config/environments/development.rb@
+
+{% highlight ruby %}
+config.active_record.mass_assignment_sanitizer = :strict
+config.active_record.auto_explain_threshold_in_seconds = 0.5
+{% endhighlight %}
+
+* @config/environments/test.rb@
+
+{% highlight ruby %}
+config.active_record.mass_assignment_sanitizer = :strict
+{% endhighlight %}
+
+* @config/initializers/wrap_parameters.rb@
+
+{% highlight ruby %}
+ActiveSupport.on_load(:active_record) do
+  self.include_root_in_json = false
+end
+{% endhighlight %}
+
 Next, add MongoMapper to your @Gemfile@, and run @bundle install@:
 
 {% highlight ruby %}


### PR DESCRIPTION
This PR helps to fix errors

``` bash
$ script/rails generate mongo_mapper:config
/usr/local/rvm/gems/ruby-1.9.3-p0@rails/gems/railties-3.2.1/lib/rails/railtie/configuration.rb:85:in `method_missing': undefined method `active_record' for #<Rails::Application::Configuration:0x007fd3fab29550> (NoMethodError)
    from /proj/config/environments/development.rb:26:in `block in <top (required)>'
```

``` bash
$ script/rails generate mongo_mapper:config
/usr/local/rvm/gems/ruby-1.9.3-p0@rails/gems/railties-3.2.1/lib/rails/railtie/configuration.rb:85:in `method_missing': undefined method `active_record' for #<Rails::Application::Configuration:0x007fa092459090> (NoMethodError)
    from /proj/config/environments/development.rb:30:in `block in <top (required)>'
```

and provides

``` bash
$ script/rails generate mongo_mapper:config
      create  config/mongo.yml
```

:+1:
