### PR TITLE
Fix: Uninitialized Class Variable @@database_name

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -3,6 +3,11 @@ require 'uri'
 
 module MongoMapper
   module Connection
+    @@connection    = nil
+    @@database      = nil
+    @@database_name = nil
+    @@config        = nil
+
     # @api public
     def connection
       @@connection ||= Mongo::Connection.new
@@ -26,9 +31,7 @@ module MongoMapper
 
     # @api public
     def database
-      if @@database_name.blank?
-        raise 'You forgot to set the default database name: MongoMapper.database = "foobar"'
-      end
+      return nil if @@database_name.blank?
 
       @@database ||= MongoMapper.connection.db(@@database_name)
     end


### PR DESCRIPTION
Allows usage of ternary (conditional) assignment for MongoMapper.database

EG:

`MongoMapper.database ||= "test"`

---

IMO, public API methods shouldn't raise exceptions unless they're "exceptional"

Fixes: #136
