### PR TITLE
MongoMapper.setup silently fails with symbol as the environment name

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -44,7 +44,7 @@ module MongoMapper
 
     # @api private
     def config_for_environment(environment)
-      env = config[environment] || {}
+      env = config[environment.to_s] || {}
       return env if env['uri'].blank?
 
       uri = URI.parse(env['uri'])

--- a/test/unit/test_mongo_mapper.rb
+++ b/test/unit/test_mongo_mapper.rb
@@ -56,6 +56,16 @@ class MongoMapperTest < Test::Unit::TestCase
       MongoMapper.connect('development')
     end
 
+    should "work with sinatra environment symbol" do
+      MongoMapper.config = {
+        'development' => {'host' => '127.0.0.1', 'port' => 27017, 'database' => 'test'}
+      }
+      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, {})
+      MongoMapper.expects(:database=).with('test')
+      Mongo::DB.any_instance.expects(:authenticate).never
+      MongoMapper.connect(:development)
+    end
+
     should "work with options" do
       MongoMapper.config = {
         'development' => {'host' => '127.0.0.1', 'port' => 27017, 'database' => 'test'}


### PR DESCRIPTION
The following code from a Sinatra app silently fails to load the right mongo environment.

``` ruby
configure do
  config = YAML.load_file(File.expand_path('conf/mongo.yml', settings.root))
  MongoMapper.setup(config, settings.environment)
end
```

The config Hash loaded by YAML contains String keys for 'test', 'development', and 'production', but Sinatra's settings.environment value is a symbol.  This patch converts the environment name to a String before using it as a Hash key.
