### PR TITLE
Added support for options for atomic modifiers plugin. This enables pass...

### DIFF
--- a/lib/mongo_mapper/plugins/modifiers.rb
+++ b/lib/mongo_mapper/plugins/modifiers.rb
@@ -73,21 +73,15 @@ module MongoMapper
           end
 
           def criteria_and_keys_from_args(args)
-            if args.length < 3
-              options = args[2].nil? ? nil : args[2]
-              updates = args[1].nil? ? nil : args[1]
-              criteria = args[0].is_a?(Hash) ? args[0] : {:id => args}
+            if args[0].is_a?(Hash)
+              criteria = args[0]
+              updates = args[1]
+              options = args[2]
             else
-              if args[0].is_a?(Hash)
-                criteria = args[0].nil? ? nil : args[0]
-                updates = args[1].nil? ? nil : args[1]
-                options = args[2].nil? ? nil : args[2]
-              else
-                split_args = args.partition{|a| a.is_a?(BSON::ObjectId)}
-                criteria = {:id => split_args[0]}
-                updates = split_args[1].first
-                options = split_args[1].last
-              end    
+              split_args = args.partition{|a| a.is_a?(BSON::ObjectId)}
+              criteria = {:id => split_args[0]}
+              updates = split_args[1].first
+              options = split_args[1].last
             end    
             [criteria_hash(criteria).to_hash, updates, options]
           end

--- a/test/functional/test_modifiers.rb
+++ b/test/functional/test_modifiers.rb
@@ -1,5 +1,5 @@
-# require 'test_helper'
-require File.expand_path("../../test_helper", __FILE__)
+require 'test_helper'
+
 class ModifierTest < Test::Unit::TestCase
   def setup
     @page_class = Doc do
@@ -329,7 +329,7 @@ class ModifierTest < Test::Unit::TestCase
         new_key_value = DateTime.now.to_s
         @page_class.increment({:title => new_key_value}, {:day_count => 1}, {:upsert => true})
         @page_class.count(:title => new_key_value).should == 1
-        # @page_class.first(:title => new_key_value).day_count.should == 1
+        @page_class.first(:title => new_key_value).day_count.should == 1
       end
       
       should "be able to pass safe option" do


### PR DESCRIPTION
...ing :upsert and :safe options to the modifier operation.

Since the mongo ruby driver already supports the upsert and safe options we should be passing those along. If there are any questions I'm more than happy to explain but these are definitely useful. We had to drop down to the ruby driver because we wanted to increment keys which might not exist yet in our use case. Once the pull request is approved and merged, I will can adjust the modifier plugin docs (which I wrote ;) ) to cover these options.
