### PR TITLE
More intuitivate :required => true for Boolean types.

### DIFF
--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -121,7 +121,11 @@ module MongoMapper
             attribute = key.name.to_sym
 
             if key.options[:required]
-              validates_presence_of(attribute)
+              if key.type == Boolean
+                validates_inclusion_of attribute, :in => [true, false]
+              else
+                validates_presence_of(attribute)
+              end
             end
 
             if key.options[:unique]

--- a/test/unit/test_validations.rb
+++ b/test/unit/test_validations.rb
@@ -245,6 +245,19 @@ class ValidationsTest < Test::Unit::TestCase
           doc.should_not have_error_on(:action)
         end
 
+        should "work with :required shortcut on Boolean type" do
+          @document.key :flag, Boolean, :required => true
+
+          doc = @document.new
+          doc.should have_error_on(:flag, 'is not included in the list')
+
+          doc.flag = true
+          doc.should_not have_error_on(:action)
+
+          doc.flag = false
+          doc.should_not have_error_on(:action)
+        end
+
         should "not have error if allow nil is true and value is nil" do
           @document.key :action, String
           @document.validates_inclusion_of :action, :in => %w(kick run), :allow_nil => true


### PR DESCRIPTION
```
key :flag, Boolean, :required => true
```

Will use validates_inclusions_of :flag, :in => [true, false] instead of validates_presence_of (which doesn't work on Boolean types).
