### PR TITLE
associations.rb:61: stack level too deep (SystemStackError) (since 0.9)

### DIFF
--- a/lib/mongo_mapper/plugins/embedded_callbacks.rb
+++ b/lib/mongo_mapper/plugins/embedded_callbacks.rb
@@ -9,22 +9,46 @@ module MongoMapper
 
         define_model_callbacks :save, :create, :update, :destroy, :only => [:before, :after]
         define_model_callbacks :touch, :only => [:after]
+
+        embedded_callbacks_on
+      end
+
+      module ClassMethods
+        def embedded_callbacks_on
+          @embedded_callbacks_status = true
+        end
+
+        def embedded_callbacks_off
+          @embedded_callbacks_status = false
+        end
+
+        def embedded_callbacks_on?
+          @embedded_callbacks_status == true
+        end
+
+        def embedded_callbacks_off?
+          !embedded_callbacks_on?
+        end
       end
 
       def run_callbacks(callback, *args, &block)
-        embedded_docs = []
 
-        embedded_associations.each do |association|
-          embedded_docs += Array(get_proxy(association).send(:load_target))
-        end
+        if self.class.embedded_callbacks_on?
+          embedded_docs = []
 
-        block = embedded_docs.inject(block) do |chain, doc|
-          if doc.class.respond_to?("_#{callback}_callbacks")
-            lambda { doc.run_callbacks(callback, *args, &chain) }
-          else
-            chain
+          embedded_associations.each do |association|
+            embedded_docs += Array(get_proxy(association).send(:load_target))
+          end
+
+          block = embedded_docs.inject(block) do |chain, doc|
+            if doc.class.respond_to?("_#{callback}_callbacks")
+              lambda { doc.run_callbacks(callback, *args, &chain) }
+            else
+              chain
+            end
           end
         end
+
         super callback, *args, &block
       end
     end


### PR DESCRIPTION
```
require 'mongo_mapper'
MongoMapper.database( 'stack_test' )

class Leaf
  include MongoMapper::EmbeddedDocument
end

class Root
  include MongoMapper::Document
  many :leafs
end

# this works for me on two machines with ruby 1.9.2 p0 p136 p180 and mongo_mapper 0.9.0
root = Root.new
800.times{ root.leafs.build() }
root.save

# this fails with the same configuration as above, but works with mongo_mapper 0.8.6
root = Root.new
1000.times{ root.leafs.build() }
root.save
```

Error Message: (that's all)
`mongo_mapper-0.9.0/lib/mongo_mapper/plugins/associations.rb:61: stack level too deep (SystemStackError)`
