### PR TITLE
Allow MongoMapper logging configuration to come from mongo.yml

### DIFF
--- a/lib/mongo_mapper/railtie.rb
+++ b/lib/mongo_mapper/railtie.rb
@@ -25,7 +25,7 @@ module MongoMapper
       config_file = Rails.root.join('config/mongo.yml')
       if config_file.file?
         config = YAML.load(ERB.new(config_file.read).result)
-        MongoMapper.setup(config, Rails.env, :logger => Rails.logger)
+        MongoMapper.setup(config, Rails.env, :logger => eval(config[Rails.env]['logger']))
       end
     end
 


### PR DESCRIPTION
This tiny patch allows different loggers (or no logger if set to nil) to be configured inside mongo.yml without resorting to dreadful hacks[1].  I have seen other solutions on the 'net which suggest making a new, manual MongoMapper connection in an initializer, but since I use Replication Sets I didn't want to uglify my code by duplicating ReplSetConnections everywhere.

(See patch comments in GitHub for usage examples.)

[1] Uses eval, which some may consider a 'dreadful hack', but it works well here.
