### PR TITLE
Add missing braces so `options` are passed as separate hash

### DIFF
--- a/documentation/plugins/modifiers.textile
+++ b/documentation/plugins/modifiers.textile
@@ -149,9 +149,9 @@ An options hash can be passed as the final argument. These options will be passe
 For example, even though a model's "safe":/documentation/plugins/safe.html setting will not apply to modifier operations, atomic updates can still be safe:
 
 {% highlight ruby %}
-@page.increment(:day_count => 1, :safe => true)
-Page.increment({:title => 'Home'}, :day_count => 1, :safe => true)
-Page.increment(@page.id, @page2.id, :day_count => 1, :safe => true)
+@page.increment({:day_count => 1}, :safe => true)
+Page.increment({:title => 'Home'}, {:day_count => 1}, :safe => true)
+Page.increment(@page.id, @page2.id, {:day_count => 1}, :safe => true)
 {% endhighlight %}
 
 Or, to do an upsert:


### PR DESCRIPTION
Thanks for merging #416, @brianhempel! I think you need braces like this. Otherwise, the `:safe` option will end up in the `updates` hash, not the `options` hash.
