### PR TITLE
Reorganisation of the documentation to help new users

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -9,7 +9,7 @@
     <li><a href="/documentation/getting-started/">Getting Started</a>
       <ul>
         <li><a href="/documentation/getting-started/rails.html">Rails installation</a></li>
-        <li><a href="/documentation/getting-started/configuration.html">Configuration</a></li>
+        <li><a href="/documentation/getting-started/sinatra.html">Sinatra installation</a></li>
         <li><a href="/documentation/getting-started/console.html">Console</a></li>
       </ul>
     </li>
@@ -19,7 +19,7 @@
         <li><a href="/documentation/documents/embedded-document.html">Embedded Document</a></li>
         <li><a href="/documentation/documents/types.html">Types</a></li>
       </ul>
-    <li><a href="/documentation/plugins/">Document plugins</a>
+    <li><a href="/documentation/plugins/">Plugins</a>
       <ul>
         <li><a href="/documentation/plugins/associations.html">Associations</a></li>
         <li><a href="/documentation/plugins/accessible.html">Accessible</a></li>
@@ -44,7 +44,6 @@
         <li><a href="/documentation/plugins/safe.html">Safe</a></li>
       </ul>
     </li>
-    <li><a href="/documentation/writing-plugins.html">Writing plugins</a></li>
     <li><a href="/documentation/exceptions.html">Exceptions</a></li>
     <li><a href="/documentation/contributing.html">Contributing</a></li>
   </ul>

--- a/documentation/documents/document.textile
+++ b/documentation/documents/document.textile
@@ -1,0 +1,17 @@
+---
+layout: documentation
+title: Document
+---
+
+Documents are first class citizens in MongoMapper. Out of the box you can persist them to collections and they can be related to other documents or embedded documents. They also come with all the typical dressings, such as "associations":/documentation/plugins/associations.html, "callbacks":/documentation/plugins/callbacks.html, "serialization":/documentation/plugins/serialization.html, "validations":/documentation/plugins/validations.html, and rich "querying":/documentation/plugins/querying.html.
+
+{% highlight ruby %}
+class Article
+  include MongoMapper::Document
+
+  key :title,        String
+  key :content,      String
+  key :published_at, Time
+  timestamps!
+end
+{% endhighlight %}

--- a/documentation/documents/embedded-document.textile
+++ b/documentation/documents/embedded-document.textile
@@ -1,0 +1,40 @@
+---
+layout: documentation
+title: EmbeddedDocument
+---
+
+Embedded documents are almost identical to "Documents":/documentation/document.html with one exception: they are saved inside of another document instead of in their own collection. For example, lets say we have orders and orders have line items.
+
+{% highlight ruby %}
+class Order
+  include MongoMapper::Document
+  many :line_items
+  timestamps!
+end
+
+class LineItem
+  include MongoMapper::EmbeddedDocument
+
+  key :name, String
+  key :quantity, Integer
+end
+
+Order.create(:line_items => [
+  LineItem.new(:name => 'Undershirt', :quantity => 5),
+  LineItem.new(:name => 'Underwear',  :quantity => 5),
+  LineItem.new(:name => 'Socks',      :quantity => 3),
+])
+{% endhighlight %}
+
+By including EmbeddedDocument instead of Document, MongoMapper knows to store the line items inside of the orders. In Mongo, this would create a collection named orders with one document that contained 3 line items. Below is what the document would look like represented in Ruby.
+
+{% highlight ruby %}{
+  "_id"=>BSON::ObjectId('4d39d708bcd1b368fc000004'),
+  "created_at"=>Fri Jan 21 18:57:12 UTC 2011,
+  "updated_at"=>Fri Jan 21 18:57:12 UTC 2011,
+  "line_items"=> [
+    {"name"=>"Undershirt", "quantity"=>5, "_id"=>BSON::ObjectId('4d39d708bcd1b368fc000001')},
+    {"name"=>"Underwear", "quantity"=>5, "_id"=>BSON::ObjectId('4d39d708bcd1b368fc000002')},
+    {"name"=>"Socks", "quantity"=>3, "_id"=>BSON::ObjectId('4d39d708bcd1b368fc000003')}
+  ]
+}{% endhighlight %}

--- a/documentation/documents/index.textile
+++ b/documentation/documents/index.textile
@@ -1,0 +1,6 @@
+---
+layout: documentation
+title: Defining documents
+---
+
+MongoMapper documents are the equivalent of models in ActiveRecord. An instantiated "MongoMapper::Document":/documentation/documents/document.html class represents a single document in a MongoDB collection. It also provides a number of class methods used for "querying the collection":/documentation/plugins/querying.html itself. You can embed documents inside other documents (rather than in their own collections) using the "MongoMapper::EmbeddedDocument":/documentation/documents/embedded-document.html class.

--- a/documentation/documents/types.textile
+++ b/documentation/documents/types.textile
@@ -1,0 +1,55 @@
+---
+layout: documentation
+title: Types
+---
+
+Because of MongoDB's ability to store rich documents, MongoMapper supports most of Ruby's data types out of the box, such as "Array":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/array.rb, "Float":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/float.rb, "Hash":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/hash.rb, "Integer":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/integer.rb, "NilClass":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/nil_class.rb, "Object":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/object.rb, "String":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/string.rb, and "Time":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/time.rb. In addition to those, MongoMapper adds support for "Binary":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/binary.rb, "Boolean":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/boolean.rb, "Date":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/date.rb, "ObjectId":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/object_id.rb, and "Set":http://github.com/jnunemaker/mongomapper/blob/master/lib/mongo_mapper/extensions/set.rb by serializing to and from Mongo safe types.
+
+h2. Custom Types
+
+The great thing about MongoMapper is that you can create your own types to make your models more pimp. All that is required to make your own type is to define the class and add the to_mongo and from_mongo class methods. For example, here is a type that always downcases strings when saving to the database:
+
+{% highlight ruby %}
+class DowncasedString
+  def self.to_mongo(value)
+    value.nil? ? nil : value.to_s.downcase
+  end
+
+  def self.from_mongo(value)
+    to_mongo(value)
+  end
+end
+{% endhighlight %}
+
+Or, if you are curious about a slightly more complex example, here is a type that is used in MongoMapper's tests:
+
+{% highlight ruby %}
+class WindowSize
+  attr_reader :width, :height
+
+  def self.to_mongo(value)
+    value.to_a
+  end
+
+  def self.from_mongo(value)
+    value.is_a?(self) ? value : WindowSize.new(value)
+  end
+
+  def initialize(*args)
+    @width, @height = args.flatten
+  end
+
+  def to_a
+    [width, height]
+  end
+
+  def eql?(other)
+    self.class.eql?(other.class) &&
+       width == other.width &&
+       height == other.height
+  end
+  alias :== :eql?
+end
+{% endhighlight %}
+
+This example actually serializes to an array for storage in Mongo, but returns an actual WindowSize object after retrieving from the database.

--- a/documentation/getting-started/index.textile
+++ b/documentation/getting-started/index.textile
@@ -1,0 +1,6 @@
+---
+layout: documentation
+title: Getting Started
+---
+
+MongoMapper is framework independent. There are setup guides for both "Rails":/documentation/getting-started/rails.html and "Sinatra":/documentation/getting-started/sinatra.html.  

--- a/documentation/getting-started/rails.textile
+++ b/documentation/getting-started/rails.textile
@@ -1,6 +1,6 @@
 ---
 layout: documentation
-title: Getting Started
+title: Installation in Rails 3
 ---
 
 Using MongoMapper with Rails 3 is easier than ever. Thanks to new features in ActiveSupport, and the new ActiveModel framework (which MongoMapper 0.9+ uses), your app can be up and running on MongoDB in a matter of seconds.
@@ -41,7 +41,14 @@ Now, you're almost ready to go, but you still need some configuration info. Gene
 script/rails generate mongo_mapper:config
 {% endhighlight %}
 
-(Note: in versions of MongoMapper below 0.9+, you were required to implement any configuration files manually using an initializer. This is now resolved, and requires nothing more on your part.)
+(Note: in versions of MongoMapper below 0.9+, you were required to implement any configuration files manually using an initializer. This is now resolved, and requires nothing more on your part.
+
+If you want to configure your application with a MongoDB URI (i.e. on "Heroku":http://heroku.com), then you can use the following settings for your production environment:
+
+{% highlight yaml %}
+production:
+ uri: <%= ENV['MONGODB_URI'] %>
+{% endhighlight %}
 
 Technically, you can initialize MongoMapper and use it to store data now. However, I like to configure Rails' model generator. Inside of the Application class (@config/application.rb@) I add:
 

--- a/documentation/getting-started/sinatra.textile
+++ b/documentation/getting-started/sinatra.textile
@@ -1,0 +1,28 @@
+---
+layout: documentation
+title: Installation in Sinatra
+---
+
+First, add MongoMapper to your @Gemfile@, and run @bundle install@:
+
+{% highlight ruby %}
+gem 'mongo_mapper'
+gem 'bson_ext'
+{% endhighlight %}
+
+If you're not using @Bundler.require@ in the top of your Sinatra application then you'll need to require the MongoMapper library:
+
+{% highlight ruby %}
+require 'mongo_mapper'
+{% endhighlight %}
+
+You'll also need to set up your MongoDB connection in your @configure@ method call. If you have a MongoDB URI for the database connection (i.e. on "Heroku":http://heroku.com):
+
+{% highlight ruby %}
+configure do
+  MongoMapper.database = ENV['MONGODB_URI']
+end
+{% endhighlight %}
+
+You can now define your models and start using MongoMapper in Sinatra!
+


### PR DESCRIPTION
These commits restructure the documentation section a bit to provide a better balance in the navigation. I found the previous subnav order quite confusing as a new-ish user, and this change should hopefully organise it in a more logical order for people unfamiliar with the project: 

<table>
  <thead>
    <tr>
      <th>The current menu order</th>
      <th>Proposed new order</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://dl.dropbox.com/u/45961/Screen%20Shot%202012-06-13%20at%2013.56.25.png"></td>
      <td><img src="https://dl.dropbox.com/u/45961/Screen%20Shot%202012-06-13%20at%2013.56.11.png"></td>
    </tr>
  </tbody>
</table>


_Sorry it cuts off; I'm on a small screen_

I created a new Documents section and relocated some of the documentation into there. There are three new pages: 'Getting Started' (the current page is now 'Rails installation'), 'Sinatra installation', and 'Documents'. 'Getting Started' and 'Documents' could probably do with some more content; maybe some links to relevant articles?

I hope this is useful and I'd be happy discuss the changes in more detail.
