### PR TITLE
Allow options hash to be passed to `safe` class method

### DIFF
--- a/lib/mongo_mapper/plugins/safe.rb
+++ b/lib/mongo_mapper/plugins/safe.rb
@@ -5,22 +5,24 @@ module MongoMapper
       extend ActiveSupport::Concern
 
       module ClassMethods
+        attr_reader :safe_options
+
         def inherited(subclass)
           super
-          subclass.safe if safe?
+          subclass.safe(safe_options) if safe?
         end
 
-        def safe
-          @safe = true
+        def safe(options = true)
+          @safe_options = options
         end
 
         def safe?
-          @safe == true
+          !!@safe_options
         end
       end
 
       def save_to_collection(options={})
-        options[:safe] = self.class.safe? unless options.key?(:safe)
+        options[:safe] = self.class.safe_options if !options.key?(:safe) && self.class.safe?
         super
       end
     end

--- a/test/functional/test_safe.rb
+++ b/test/functional/test_safe.rb
@@ -14,6 +14,13 @@ class SafeTest < Test::Unit::TestCase
       should "set subclass safe setting on" do
         inherited = Class.new(Doc() { safe })
         inherited.should be_safe
+        inherited.safe_options.should == true
+      end
+
+      should "set subclass safe setting to same options hash as superclass" do
+        inherited = Class.new(Doc() { safe(:j => true) })
+        inherited.should be_safe
+        inherited.safe_options.should == {:j => true}
       end
     end
 
@@ -39,6 +46,67 @@ class SafeTest < Test::Unit::TestCase
       end
 
       context "using safe setting from class" do
+        should "pass :safe => true option to save" do
+          instance = @klass.new(:email => 'john@doe.com')
+          Mongo::Collection.any_instance.expects(:save).once.with({'_id' => instance.id, 'email' => 'john@doe.com'}, {:safe => true})
+          instance.save!
+        end
+
+        should "work fine when all is well" do
+          assert_nothing_raised do
+            @klass.new(:email => 'john@doe.com').save
+          end
+        end
+
+        should "raise error when operation fails" do
+          assert_raises(Mongo::OperationFailure) do
+            2.times do
+              @klass.new(:email => 'john@doe.com').save
+            end
+          end
+        end
+      end
+
+      context "overriding safe setting" do
+        should "raise error if safe is true" do
+          assert_raises(Mongo::OperationFailure) do
+            2.times do
+              @klass.new(:email => 'john@doe.com').save(:safe => true)
+            end
+          end
+        end
+
+        should "not raise error if safe is false" do
+          assert_nothing_raised do
+            2.times do
+              @klass.new(:email => 'john@doe.com').save(:safe => false)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  context "a safe document with options hash" do
+    setup do
+      @klass = Doc() do
+        safe(:j => true)
+      end
+    end
+    teardown { drop_indexes(@klass) }
+
+    context "#save" do
+      setup do
+        @klass.ensure_index :email, :unique => true
+      end
+
+      context "using safe setting from class" do
+        should "pass :safe => options_hash to save" do
+          instance = @klass.new(:email => 'john@doe.com')
+          Mongo::Collection.any_instance.expects(:save).once.with({'_id' => instance.id, 'email' => 'john@doe.com'}, {:safe => {:j => true}})
+          instance.save!
+        end
+
         should "work fine when all is well" do
           assert_nothing_raised do
             @klass.new(:email => 'john@doe.com').save


### PR DESCRIPTION
Like this:

``` ruby
class Order
  include MongoMapper::Document
  safe(j: true, w: 'majority')
end
```

See http://www.mongodb.org/display/DOCS/getLastError+Command for details.

I'll create a separate pull-request for the documentation.
