### PR TITLE
Leaving updated_at alone if nothing changed.

### DIFF
--- a/lib/mongo_mapper/embedded_document.rb
+++ b/lib/mongo_mapper/embedded_document.rb
@@ -12,6 +12,7 @@ module MongoMapper
     include Plugins::Equality
     include Plugins::Inspect
     include Plugins::Keys
+    include Plugins::Dirty # for now dirty needs to be after keys
     include Plugins::Logger
     include Plugins::Persistence
     include Plugins::Accessible

--- a/lib/mongo_mapper/plugins/timestamps.rb
+++ b/lib/mongo_mapper/plugins/timestamps.rb
@@ -15,7 +15,7 @@ module MongoMapper
       def update_timestamps
         now = Time.now.utc
         self[:created_at] = now if !persisted? && !created_at?
-        self[:updated_at] = now
+        self[:updated_at] = now if changed?
       end
     end
   end

--- a/test/functional/test_timestamps.rb
+++ b/test/functional/test_timestamps.rb
@@ -58,5 +58,17 @@ class TimestampsTest < Test::Unit::TestCase
       doc.created_at.to_f.should be_close(old_created_at, 0.001)
       doc.updated_at.to_f.should be_close(new_updated_at.to_f, 0.001)
     end
+
+    should "leave updated_at alone if nothing changed" do
+      doc = @klass.create(:first_name => 'John', :age => 27)
+      old_updated_at = doc.updated_at
+
+      Timecop.freeze(Time.now + 5.seconds) do
+        doc.save
+      end
+
+      doc.updated_at.should == old_updated_at
+    end
+
   end
 end


### PR DESCRIPTION
I've made simple patch, regarding leaving updated_at alone if nothing has changed when doing save - just as it's happening with active_model. With tests.

Unfortunately, that change had broken EmbeddedDocument test. Because there is anonymous ancestor injected somewhere (I suppose by ActiveModel::Dirty), apparently that's okay with mongomapper's Document but not with EmbeddedDocument. I've tried to fix it but I've failed - I'm not proficient enough.

I'll appriciate if you could fix it or give me instructions how to start fixing it.

Best regards,
Karol Ciba
