### PR TITLE
Support for the new mongo hosts option format

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -70,7 +70,11 @@ module MongoMapper
       end
 
       MongoMapper.connection = if env['hosts']
-        Mongo::ReplSetConnection.new( *env['hosts'].push(options) )
+        if env['hosts'].first.is_a?(String)
+          Mongo::ReplSetConnection.new( env['hosts'], options )
+        else
+          Mongo::ReplSetConnection.new( *env['hosts'].push(options) )
+        end
       else
         Mongo::Connection.new(env['host'], env['port'], options)
       end

--- a/test/unit/test_mongo_mapper.rb
+++ b/test/unit/test_mongo_mapper.rb
@@ -116,7 +116,7 @@ class MongoMapperTest < Test::Unit::TestCase
       assert_raises(MongoMapper::InvalidScheme) { MongoMapper.connect('development') }
     end
 
-    should "create a replica set connection if config contains multiple hosts" do
+    should "create a replica set connection if config contains multiple hosts in the old format" do
       MongoMapper.config = {
         'development' => {
           'hosts' => [ ['127.0.0.1', 27017], ['localhost', 27017] ],
@@ -125,6 +125,20 @@ class MongoMapperTest < Test::Unit::TestCase
       }
 
       Mongo::ReplSetConnection.expects(:new).with( ['127.0.0.1', 27017], ['localhost', 27017], {'read_secondary' => true} )
+      MongoMapper.expects(:database=).with('test')
+      Mongo::DB.any_instance.expects(:authenticate).never
+      MongoMapper.connect('development', 'read_secondary' => true)
+    end
+
+    should "create a replica set connection if config contains multiple hosts in the new format" do
+      MongoMapper.config = {
+        'development' => {
+          'hosts' => ['127.0.0.1:27017', 'localhost:27017'],
+          'database' => 'test'
+        }
+      }
+
+      Mongo::ReplSetConnection.expects(:new).with( ['127.0.0.1:27017', 'localhost:27017'], {'read_secondary' => true} )
       MongoMapper.expects(:database=).with('test')
       Mongo::DB.any_instance.expects(:authenticate).never
       MongoMapper.connect('development', 'read_secondary' => true)


### PR DESCRIPTION
See  https://github.com/mongodb/mongo-ruby-driver/blob/bf9f12d05fe7e4833640c5ebd6f45bfcdd9df5f0/lib/mongo/repl_set_connection.rb#L102-112
