### PR TITLE
partial records incorrectly added to IdentityMap when using Plucky::Query#each

### DIFF
--- a/lib/mongo_mapper/plugins/identity_map.rb
+++ b/lib/mongo_mapper/plugins/identity_map.rb
@@ -76,6 +76,14 @@ module MongoMapper
               end
             end
           end
+
+          def find_each(opts={}, &block)
+            query = clone.amend(opts)
+            super(opts) do |doc|
+              model.remove_documents_from_map(doc) if query.fields?
+              block.call(doc) unless block.nil?
+            end
+          end
         end
 
         def query(opts={})

--- a/test/functional/test_identity_map.rb
+++ b/test/functional/test_identity_map.rb
@@ -372,6 +372,13 @@ class IdentityMapTest < Test::Unit::TestCase
         assert_not_in_map(@person)
       end
 
+      should "not add to map using where and each" do
+        @person_class.where(:id => @person.id).each{|_|}
+        assert_in_map(@person)
+        @person_class.where(:id => @person.id).only(:id).each{|_|}
+        assert_not_in_map(@person)
+      end
+
       should "return nil if not found" do
         @person_class.fields(:name).find(BSON::ObjectId.new).should be_nil
       end


### PR DESCRIPTION
Here's what I noticed 

``` ruby
> MongoMapper::Plugins::IdentityMap.repository.clear
=> {}
> Tag.where(:app_id => 6).order(:name.asc).only(:id, :name).each {|_|}
=> <Mongo::Cursor:0x3fc9209367e0 namespace='my_app_development.tags' @selector={:app_id=>6} @cursor_id=>
> MongoMapper::Plugins::IdentityMap.repository.count
=> 51
```

subsequent queries for complete tags would only return the partial records loaded from the identity map.

This behaves differently to using #all.
