### PR TITLE
Fix Travis MongoMapper build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ rvm:
 notifications:
   email: false
 bundler_args: --without development
+services: mongodb


### PR DESCRIPTION
Declare TravisCI mongo service dependency.

Attempt to fix Travis build by enabling the mongo service.

This service was disabled by default and now requires an explicit service config.
