### PR TITLE
Support non-ObjectID ids being given to modifiers.

### DIFF
--- a/lib/mongo_mapper/plugins/modifiers.rb
+++ b/lib/mongo_mapper/plugins/modifiers.rb
@@ -77,14 +77,13 @@ module MongoMapper
           def criteria_and_keys_from_args(args)
             if args[0].is_a?(Hash)
               criteria = args[0]
-              updates = args[1]
-              options = args[2]
+              updates  = args[1]
+              options  = args[2]
             else
-              split_args = args.partition{|a| a.is_a?(BSON::ObjectId)}
-              criteria = {:id => split_args[0]}
-              updates = split_args[1].first
-              options = split_args[1].last
+              criteria, (updates, options) = args.partition { |a| !a.is_a?(Hash) }
+              criteria = { :id => criteria }
             end
+
             [criteria_hash(criteria).to_hash, updates, options]
           end
       end

--- a/test/functional/test_modifiers.rb
+++ b/test/functional/test_modifiers.rb
@@ -109,6 +109,13 @@ class ModifierTest < Test::Unit::TestCase
         assert_page_counts @page, 1, 2, 3
         assert_page_counts @page2, 1, 2, 3
       end
+
+      should "work with ids given as strings" do
+        @page_class.increment(@page.id.to_s, @page2.id.to_s, :day_count => 1, :week_count => 2, :month_count => 3)
+
+        assert_page_counts @page, 1, 2, 3
+        assert_page_counts @page2, 1, 2, 3
+      end
     end
 
     context "decrement" do
@@ -133,6 +140,13 @@ class ModifierTest < Test::Unit::TestCase
 
       should "decrement with positive or negative numbers" do
         @page_class.decrement(@page.id, @page2.id, :day_count => -1, :week_count => 2, :month_count => -3)
+
+        assert_page_counts @page, 0, 0, 0
+        assert_page_counts @page2, 0, 0, 0
+      end
+
+      should "work with ids given as strings" do
+        @page_class.decrement(@page.id.to_s, @page2.id.to_s, :day_count => -1, :week_count => 2, :month_count => -3)
 
         assert_page_counts @page, 0, 0, 0
         assert_page_counts @page2, 0, 0, 0


### PR DESCRIPTION
The partially broken by cf82ec6e where it allowed a single ID to be
passed and it would work as expected. This also adds support for
multiple IDs to be provided.

Ran into this issue today updating an app from 0.9.2 to 0.12.0 (originally semi-broken in 0.11.1).
