### PR TITLE
Provide a fix for many associations not yielding to each in callbacks.

### DIFF
--- a/lib/mongo_mapper/plugins/associations/many_documents_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/many_documents_proxy.rb
@@ -5,7 +5,7 @@ module MongoMapper
       class ManyDocumentsProxy < Collection
         include DynamicQuerying::ClassMethods
 
-        def_delegators :query, *(Querying::Methods - [:to_a, :size, :empty?])
+        def_delegators :query, *(Querying::Methods - [:each, :to_a, :size, :empty?])
 
         def replace(docs)
           load_target
@@ -69,6 +69,10 @@ module MongoMapper
 
         def save_to_collection(options={})
           @target.each { |doc| doc.save(options) } if @target
+        end
+
+        def each(&block)
+          load_target.each(&block)
         end
 
         protected


### PR DESCRIPTION
:warning: Feedback / review wanted

Ran into an issue when iterating over a many association in a
before_save callback on a document. For an association named foos,
`foos.inspect` would show the items but `foos.each` would never yield to
the given block since it appears to be empty.

The original issue I was tracking down was that instead of not yielding
it was yielding instances of Mongo::Cursor instead of the association
object. I haven't been able to recreate that case outside of the app.

I don't know if this is the best way to fix the issue. We started seeing the above issue in our app starting at b965105e.
