### PR TITLE
Update for recent changes in mongo 1.8.0.

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -10,7 +10,7 @@ module MongoMapper
 
     # @api public
     def connection
-      @@connection ||= Mongo::Connection.new
+      @@connection ||= Mongo::MongoClient.new
     end
 
     # @api public
@@ -75,12 +75,12 @@ module MongoMapper
 
       MongoMapper.connection = if env['hosts']
         if env['hosts'].first.is_a?(String)
-          Mongo::ReplSetConnection.new( env['hosts'], options )
+          Mongo::MongoReplicaSetClient.new( env['hosts'], options )
         else
-          Mongo::ReplSetConnection.new( *env['hosts'].push(options) )
+          Mongo::MongoReplicaSetClient.new( *env['hosts'].push(options) )
         end
       else
-        Mongo::Connection.new(env['host'], env['port'], options)
+        Mongo::MongoClient.new(env['host'], env['port'], options)
       end
 
       MongoMapper.database = env['database']

--- a/test/functional/test_logger.rb
+++ b/test/functional/test_logger.rb
@@ -5,7 +5,7 @@ class LoggerTest < Test::Unit::TestCase
     setup do
       @output = StringIO.new
       @logger = Logger.new(@output)
-      MongoMapper.connection = Mongo::Connection.new('127.0.0.1', 27017, :logger => @logger)
+      MongoMapper.connection = Mongo::MongoClient.new('127.0.0.1', 27017, :logger => @logger)
     end
 
     should "be able to get access to that logger" do

--- a/test/functional/test_sci.rb
+++ b/test/functional/test_sci.rb
@@ -35,7 +35,7 @@ class SciTest < Test::Unit::TestCase
     should "use the same connection in the subclass" do
       parent_class = Class.new do
         include MongoMapper::Document
-        connection Mongo::Connection.new
+        connection Mongo::MongoClient.new
       end
 
       child_class = Class.new(parent_class) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,6 +88,6 @@ log_dir = File.expand_path('../../log', __FILE__)
 FileUtils.mkdir_p(log_dir) unless File.exist?(log_dir)
 logger = Logger.new(log_dir + '/test.log')
 
-MongoMapper.connection = Mongo::Connection.new('127.0.0.1', 27017, :logger => logger)
+MongoMapper.connection = Mongo::MongoClient.new('127.0.0.1', 27017, :logger => logger)
 MongoMapper.database = "test"
 MongoMapper.database.collections.each { |c| c.drop_indexes }

--- a/test/unit/test_document.rb
+++ b/test/unit/test_document.rb
@@ -21,11 +21,11 @@ class DocumentTest < Test::Unit::TestCase
     end
 
     should "have a connection" do
-      @document.connection.should be_instance_of(Mongo::Connection)
+      @document.connection.should be_instance_of(Mongo::MongoClient)
     end
 
     should "allow setting different connection without affecting the default" do
-      conn = Mongo::Connection.new
+      conn = Mongo::MongoClient.new
       @document.connection conn
       @document.connection.should == conn
       @document.connection.should_not == MongoMapper.connection

--- a/test/unit/test_mongo_mapper.rb
+++ b/test/unit/test_mongo_mapper.rb
@@ -4,14 +4,14 @@ class Address; end
 
 class MongoMapperTest < Test::Unit::TestCase
   should "be able to write and read connection" do
-    conn = Mongo::Connection.new
+    conn = Mongo::MongoClient.new
     MongoMapper.connection = conn
     MongoMapper.connection.should == conn
   end
 
   should "default connection to new mongo ruby driver" do
     MongoMapper.connection = nil
-    MongoMapper.connection.should be_instance_of(Mongo::Connection)
+    MongoMapper.connection.should be_instance_of(Mongo::MongoClient)
   end
 
   should "be able to write and read default database" do
@@ -40,7 +40,7 @@ class MongoMapperTest < Test::Unit::TestCase
       MongoMapper.config = {
         'development' => {'host' => '127.0.0.1', 'port' => 27017, 'database' => 'test'}
       }
-      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, {})
+      Mongo::MongoClient.expects(:new).with('127.0.0.1', 27017, {})
       MongoMapper.expects(:database=).with('test')
       Mongo::DB.any_instance.expects(:authenticate).never
       MongoMapper.connect('development')
@@ -50,7 +50,7 @@ class MongoMapperTest < Test::Unit::TestCase
       MongoMapper.config = {
         'development' => {'uri' => 'mongodb://127.0.0.1:27017/test'}
       }
-      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, {})
+      Mongo::MongoClient.expects(:new).with('127.0.0.1', 27017, {})
       MongoMapper.expects(:database=).with('test')
       Mongo::DB.any_instance.expects(:authenticate).never
       MongoMapper.connect('development')
@@ -60,7 +60,7 @@ class MongoMapperTest < Test::Unit::TestCase
       MongoMapper.config = {
         'development' => {'host' => '127.0.0.1', 'port' => 27017, 'database' => 'test'}
       }
-      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, {})
+      Mongo::MongoClient.expects(:new).with('127.0.0.1', 27017, {})
       MongoMapper.expects(:database=).with('test')
       Mongo::DB.any_instance.expects(:authenticate).never
       MongoMapper.connect(:development)
@@ -71,7 +71,7 @@ class MongoMapperTest < Test::Unit::TestCase
         'development' => {'host' => '127.0.0.1', 'port' => 27017, 'database' => 'test'}
       }
       connection, logger = mock('connection'), mock('logger')
-      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, :logger => logger)
+      Mongo::MongoClient.expects(:new).with('127.0.0.1', 27017, :logger => logger)
       MongoMapper.connect('development', :logger => logger)
     end
 
@@ -80,7 +80,7 @@ class MongoMapperTest < Test::Unit::TestCase
         'development' => {'host' => '127.0.0.1', 'port' => 27017, 'database' => 'test', 'ssl' => true}
       }
       connection, logger = mock('connection'), mock('logger')
-      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, :logger => logger, :ssl => true)
+      Mongo::MongoClient.expects(:new).with('127.0.0.1', 27017, :logger => logger, :ssl => true)
       MongoMapper.connect('development', :logger => logger)
     end
 
@@ -89,7 +89,7 @@ class MongoMapperTest < Test::Unit::TestCase
         'development' => {'host' => '127.0.0.1', 'port' => 27017, 'database' => 'test', 'ssl' => false}
       }
       connection, logger = mock('connection'), mock('logger')
-      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, :logger => logger, :ssl => false)
+      Mongo::MongoClient.expects(:new).with('127.0.0.1', 27017, :logger => logger, :ssl => false)
       MongoMapper.connect('development', :logger => logger)
     end
 
@@ -98,7 +98,7 @@ class MongoMapperTest < Test::Unit::TestCase
         'development' => {'host' => '192.168.1.1', 'port' => 2222, 'database' => 'test', 'options' => {'safe' => true}}
       }
       connection, logger = mock('connection'), mock('logger')
-      Mongo::Connection.expects(:new).with('192.168.1.1', 2222, :logger => logger, :safe => true)
+      Mongo::MongoClient.expects(:new).with('192.168.1.1', 2222, :logger => logger, :safe => true)
       MongoMapper.connect('development', :logger => logger)
     end
 
@@ -107,7 +107,7 @@ class MongoMapperTest < Test::Unit::TestCase
         'development' => {'uri' => 'mongodb://127.0.0.1:27017/test'}
       }
       connection, logger = mock('connection'), mock('logger')
-      Mongo::Connection.expects(:new).with('127.0.0.1', 27017, :logger => logger)
+      Mongo::MongoClient.expects(:new).with('127.0.0.1', 27017, :logger => logger)
       MongoMapper.connect('development', :logger => logger)
     end
 
@@ -142,7 +142,7 @@ class MongoMapperTest < Test::Unit::TestCase
         }
       }
 
-      Mongo::ReplSetConnection.expects(:new).with( ['127.0.0.1', 27017], ['localhost', 27017], {'read_secondary' => true} )
+      Mongo::MongoReplicaSetClient.expects(:new).with( ['127.0.0.1', 27017], ['localhost', 27017], {'read_secondary' => true} )
       MongoMapper.expects(:database=).with('test')
       Mongo::DB.any_instance.expects(:authenticate).never
       MongoMapper.connect('development', 'read_secondary' => true)
@@ -156,7 +156,7 @@ class MongoMapperTest < Test::Unit::TestCase
         }
       }
 
-      Mongo::ReplSetConnection.expects(:new).with( ['127.0.0.1:27017', 'localhost:27017'], {'read_secondary' => true} )
+      Mongo::MongoReplicaSetClient.expects(:new).with( ['127.0.0.1:27017', 'localhost:27017'], {'read_secondary' => true} )
       MongoMapper.expects(:database=).with('test')
       Mongo::DB.any_instance.expects(:authenticate).never
       MongoMapper.connect('development', 'read_secondary' => true)


### PR DESCRIPTION
MongoDB has recently put trough a series of commits that deprecate certain class names as well as deprecate the `:safe` option in favor of `:w` (write concern). This changeset updates mongomapper to use Mongo::MongoClient and Mongo::MongoReplicaSetClient instead of Mongo::Connection and Mongo::ReplSetConnection.

However, there is a bit more work to be done, the 1.8.0 ruby driver deprecates safe and uses :w, where:

``` ruby
@mongo_client.save({:doc => 'foo'}, {:w => 0})  # writes are not acknowledged
@mongo_client.save({:doc => 'foo'}, {:w => 1})  # writes are acknowledged (mongo client DEFAULT as of 1.8)
@mongo_client.save({:doc => 'foo'}, {:w => 2})  # replica set acknowledged
```

As the writes are now acknowledged by default, the Safe plugin may be removed. (I was unsure whether to remove it or not, so I did not yet include that changeset.)

The gem dependency should also be bumped to version 1.8.0 for mongo.
