### PR TITLE
Update documentation/getting-started/rails.textile

### DIFF
--- a/documentation/getting-started/rails.textile
+++ b/documentation/getting-started/rails.textile
@@ -59,8 +59,9 @@ end
 {% endhighlight %}
 
 And also I commented this line out:
+
 {% highlight ruby %}
-#    config.active_record.whitelist_attributes = true 
+# config.active_record.whitelist_attributes = true 
 {% endhighlight %}
 
 


### PR DESCRIPTION
adding 
#  config.active_record.whitelist_attributes = true  to the docs, to avoid ppl getting this error:

rvm/gems/ruby-1.9.3-p194/gems/railties-3.2.9/lib/rails/railtie/configuration.rb:85:in `method_missing': undefined method`active_record' for #Rails::Application::Configuration:0x007fe6f43d2718 (NoMethodError)
