### PR TITLE
Added record_timestamps class var to the timestamps plugin

### DIFF
--- a/lib/mongo_mapper/plugins/timestamps.rb
+++ b/lib/mongo_mapper/plugins/timestamps.rb
@@ -4,6 +4,11 @@ module MongoMapper
     module Timestamps
       extend ActiveSupport::Concern
 
+      included do
+        class_attribute :record_timestamps
+        self.record_timestamps = true
+      end
+
       module ClassMethods
         def timestamps!
           key :created_at, Time
@@ -13,9 +18,11 @@ module MongoMapper
       end
 
       def update_timestamps
-        now = Time.now.utc
-        self[:created_at] = now if !persisted? && !created_at?
-        self[:updated_at] = now
+        if self.record_timestamps then
+          now = Time.now.utc
+          self[:created_at] = now if !persisted? && !created_at?
+          self[:updated_at] = now
+        end
       end
     end
   end

--- a/test/functional/test_timestamps.rb
+++ b/test/functional/test_timestamps.rb
@@ -1,6 +1,19 @@
 require 'test_helper'
 
 class TimestampsTest < Test::Unit::TestCase
+  context "included" do
+    setup do
+      @klass = Doc do
+        key :first_name, String
+      end
+      @klass.timestamps!
+    end
+
+    should "set record_timestamps to true" do
+      @klass.record_timestamps.should be(true)
+    end
+  end
+
   context "timestamping" do
     setup do
       @klass = Doc do
@@ -12,51 +25,73 @@ class TimestampsTest < Test::Unit::TestCase
       @klass.timestamps!
     end
 
-    should "set created_at and updated_at on create" do
-      doc = @klass.new(:first_name => 'John', :age => 27)
-      doc.created_at.should be(nil)
-      doc.updated_at.should be(nil)
-      doc.save
-      doc.created_at.should_not be(nil)
-      doc.updated_at.should_not be(nil)
-    end
-
-    should "not overwrite created_at if it already exists" do
-      original_created_at = 1.month.ago
-      doc = @klass.new(:first_name => 'John', :age => 27, :created_at => original_created_at)
-      doc.created_at.to_i.should == original_created_at.to_i
-      doc.updated_at.should be_nil
-      doc.save
-      doc.created_at.to_i.should == original_created_at.to_i
-      doc.updated_at.should_not be_nil
-    end
-
-    should "set updated_at on field update but leave created_at alone" do
-      doc = @klass.create(:first_name => 'John', :age => 27)
-      old_created_at = doc.created_at
-      old_updated_at = doc.updated_at
-      doc.first_name = 'Johnny'
-
-      Timecop.freeze(Time.now + 5.seconds) do
+    context "when #record_timestamps is set to true" do
+      should "set created_at and updated_at on create" do
+        doc = @klass.new(:first_name => 'John', :age => 27)
+        doc.created_at.should be(nil)
+        doc.updated_at.should be(nil)
         doc.save
+        doc.created_at.should_not be(nil)
+        doc.updated_at.should_not be(nil)
       end
 
-      doc.created_at.should == old_created_at
-      doc.updated_at.should_not == old_updated_at
+      should "not overwrite created_at if it already exists" do
+        original_created_at = 1.month.ago
+        doc = @klass.new(:first_name => 'John', :age => 27, :created_at => original_created_at)
+        doc.created_at.to_i.should == original_created_at.to_i
+        doc.updated_at.should be_nil
+        doc.save
+        doc.created_at.to_i.should == original_created_at.to_i
+        doc.updated_at.should_not be_nil
+      end
+
+      should "set updated_at on field update but leave created_at alone" do
+        doc = @klass.create(:first_name => 'John', :age => 27)
+        old_created_at = doc.created_at
+        old_updated_at = doc.updated_at
+        doc.first_name = 'Johnny'
+
+        Timecop.freeze(Time.now + 5.seconds) do
+          doc.save
+        end
+
+        doc.created_at.should == old_created_at
+        doc.updated_at.should_not == old_updated_at
+      end
+
+      should "set updated_at on document update but leave created_at alone" do
+        doc = @klass.create(:first_name => 'John', :age => 27)
+        old_created_at = doc.created_at.to_f
+
+        new_updated_at = Time.now + 5.seconds
+        Timecop.freeze(new_updated_at) do
+          @klass.update(doc._id, { :first_name => 'Johnny' })
+        end
+
+        doc = doc.reload
+        doc.created_at.to_f.should be_close(old_created_at, 0.001)
+        doc.updated_at.to_f.should be_close(new_updated_at.to_f, 0.001)
+      end
     end
 
-    should "set updated_at on document update but leave created_at alone" do
-      doc = @klass.create(:first_name => 'John', :age => 27)
-      old_created_at = doc.created_at.to_f
-
-      new_updated_at = Time.now + 5.seconds
-      Timecop.freeze(new_updated_at) do
-        @klass.update(doc._id, { :first_name => 'Johnny' })
+    context "when #record_timestamps is set to false" do
+      setup do
+        @klass.record_timestamps = false
       end
 
-      doc = doc.reload
-      doc.created_at.to_f.should be_close(old_created_at, 0.001)
-      doc.updated_at.to_f.should be_close(new_updated_at.to_f, 0.001)
+      teardown do
+        @klass.record_timestamps = true
+      end
+
+      should "doesn't set updated_at on document create" do
+        doc = @klass.create(:first_name => "John")
+        doc.created_at.should be_nil
+      end
+
+      should "doesn't set updated_at on document create" do
+        doc = @klass.create(:first_name => "John")
+        doc.updated_at.should be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Hey,

I noticed, that mongo_mapper ignores the ActiveRecord::Base.record_timestamps feature. This is a flag, that allows user to disable/enable timestamps auto-updates, in order i.e. to set some legacy data in the updated_at field. I saw someone had needed something similar in some of the old email threads: https://groups.google.com/forum/?fromgroups=#!topic/mongomapper/bzPA5gEUrKw

My patch works similar as ActiveRecord: It sets the class variable record_timestamps and disables updating timestamps when it's false.

Please let me know what do you think about this.

Best regards,
Kamil Bednarz
