### PR TITLE
Update bundler and fix mocha dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
@@ -11,6 +11,6 @@ group :test do
   gem 'jnunemaker-matchy', '~> 0.4', :require => 'matchy'
   gem 'shoulda',           '~> 2.11'
   gem 'timecop',           '~> 0.3'
-  gem 'mocha',             '~> 0.10'
+  gem 'mocha',             '~> 0.10.0'
   gem 'rack-test',         '~> 0.6'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'bundler/setup'
 
-$:.unshift File.expand_path('../../lib', __FILE__)
 require 'mongo_mapper'
 require 'fileutils'
 require 'ostruct'


### PR DESCRIPTION
Latest mocha does not work with mongomapper, this pull request fixes it.

I have also changed the Gemfile to rely on ssl rubygems and removed unecessary load path setup.
