### PR TITLE
Mongo driver requires that read preference to be type of symbol

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -68,6 +68,7 @@ module MongoMapper
       if env['options'].is_a?(Hash)
         options = env['options'].symbolize_keys.merge(options)
       end
+      options[:read] = options[:read].to_sym if options[:read].is_a? String
 
       if env.key?('ssl')
         options[:ssl] = env['ssl']


### PR DESCRIPTION
Using in Rails, with config/mongo.yml as following:

``` yaml
defaults: &defaults
  port: 27017
  options:
    w: 0
    pool_size: 50
    slave_ok: false
    ssl: false
    logger: false

# set these environment variables on your prod server
production:
  <<: *defaults
  hosts: 
    - w-finfo1:27017
    - w-finfo1:37017
  database: fishnet_production
  options:
    read: secondary_preferred
```

Got this in passenger error log.

``` bash
[ pid=28815 thr=14415900 file=utils.rb:176 time=2013-04-08 14:05:57.806 ]: *** Exception PhusionPassenger::UnknownError in PhusionPassenger::Rack::ApplicationSpawner (secondary_preferred is not a valid read preference. Please specify one of the following read preferences as a symbol: [:primary, :primary_preferred, :secondary, :secondary_preferred, :nearest] (Mongo::MongoArgumentError)) (process 28815, thread #<Thread:0x00000001b7f038>):
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo-1.8.3/lib/mongo/util/read_preference.rb:31:in `validate'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo-1.8.3/lib/mongo/mongo_client.rb:607:in `setup'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo-1.8.3/lib/mongo/mongo_replica_set_client.rb:466:in `setup'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo-1.8.3/lib/mongo/mongo_replica_set_client.rb:152:in `initialize'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo-1.8.3/lib/mongo/legacy.rb:53:in `initialize'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo_mapper-0.12.0/lib/mongo_mapper/connection.rb:74:in `new'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo_mapper-0.12.0/lib/mongo_mapper/connection.rb:74:in `connect'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo_mapper-0.12.0/lib/mongo_mapper/connection.rb:89:in `setup'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/mongo_mapper-0.12.0/lib/mongo_mapper/railtie.rb:28:in `block in <class:Railtie>'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/railties-3.2.12/lib/rails/initializable.rb:30:in `instance_exec'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/railties-3.2.12/lib/rails/initializable.rb:30:in `run'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/railties-3.2.12/lib/rails/initializable.rb:55:in `block in run_initializers'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/railties-3.2.12/lib/rails/initializable.rb:54:in `each'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/railties-3.2.12/lib/rails/initializable.rb:54:in `run_initializers'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/railties-3.2.12/lib/rails/application.rb:136:in `initialize!'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/railties-3.2.12/lib/rails/railtie/configurable.rb:30:in `method_missing'
    from /home/q/system/fishnet/config/environment.rb:13:in `<top (required)>'
    from config.ru:3:in `require'
    from config.ru:3:in `block in <main>'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/rack-1.4.5/lib/rack/builder.rb:51:in `instance_eval'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/rack-1.4.5/lib/rack/builder.rb:51:in `initialize'
    from config.ru:1:in `new'
    from config.ru:1:in `<main>'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/rack/application_spawner.rb:225:in `eval'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/rack/application_spawner.rb:225:in `load_rack_app'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/rack/application_spawner.rb:157:in `block in initialize_server'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/utils.rb:563:in `report_app_init_status'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/rack/application_spawner.rb:154:in `initialize_server'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/abstract_server.rb:204:in `start_synchronously'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/abstract_server.rb:180:in `start'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/rack/application_spawner.rb:129:in `start'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/spawn_manager.rb:253:in `block (2 levels) in spawn_rack_application'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/abstract_server_collection.rb:132:in `lookup_or_add'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/spawn_manager.rb:246:in `block in spawn_rack_application'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/abstract_server_collection.rb:82:in `block in synchronize'
    from <internal:prelude>:10:in `synchronize'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/abstract_server_collection.rb:79:in `synchronize'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/spawn_manager.rb:244:in `spawn_rack_application'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/spawn_manager.rb:137:in `spawn_application'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/spawn_manager.rb:275:in `handle_spawn_application'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/abstract_server.rb:357:in `server_main_loop'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/lib/phusion_passenger/abstract_server.rb:206:in `start_synchronously'
    from /usr/local/ruby-1.9.3/lib/ruby/gems/1.9.1/gems/passenger-3.0.19/helper-scripts/passenger-spawn-server:99:in `<main>'
```

This patch ensures that `read` is a Symbol before creating RS connection.
