### PR TITLE
Limit subclass scopes to subclasses

### DIFF
--- a/lib/mongo_mapper/plugins/scopes.rb
+++ b/lib/mongo_mapper/plugins/scopes.rb
@@ -10,11 +10,12 @@ module MongoMapper
 
       module ClassMethods
         def scope(name, scope_options={})
-          scopes[name] = lambda do |*args|
+          # Assign to _scopes instead of using []= to avoid mixing subclass scopes
+          self._scopes = scopes.merge(name => lambda do |*args|
             result = scope_options.is_a?(Proc) ? scope_options.call(*args) : scope_options
             result = self.query(result) if result.is_a?(Hash)
             self.query.merge(result)
-          end
+          end)
           singleton_class.send :define_method, name, &scopes[name]
         end
 

--- a/test/functional/test_scopes.rb
+++ b/test/functional/test_scopes.rb
@@ -148,7 +148,10 @@ class ScopesTest < Test::Unit::TestCase
         Item.collection.remove
 
         class ::Page < ::Item; end
-        class ::Blog < ::Item; end
+        class ::Blog < ::Item
+          key :slug, String
+          scope :by_slug, lambda { |slug| {:slug => slug} }
+        end
       end
 
       teardown do
@@ -165,6 +168,11 @@ class ScopesTest < Test::Unit::TestCase
         item = Item.create(:title => 'Home')
         page = Page.create(:title => 'Home')
         Page.by_title('Home').first.should == page
+      end
+
+      should "limit subclass scopes to subclasses" do
+        Item.scopes.keys.map(&:to_s).sort.should == %w(by_title published)
+        Blog.scopes.keys.map(&:to_s).sort.should == %w(by_slug by_title published)
       end
     end
   end


### PR DESCRIPTION
Prior to this change, scopes added to subclasses would be visible on the
superclass
