### PR TITLE
Relax mongo driver requirement to permit 1.9

### DIFF
--- a/mongo_mapper.gemspec
+++ b/mongo_mapper.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel',   '~> 3.0'
   s.add_dependency 'activesupport', '~> 3.0'
   s.add_dependency 'plucky',        '~> 0.6.3'
-  s.add_dependency 'mongo',         '~> 1.8.0'
+  s.add_dependency 'mongo',         '~> 1.8'
 end


### PR DESCRIPTION
The Mongo team just released the 1.9 version of the Ruby driver, which includes some important null reference fixes in the BSON driver, as well as other minor fixes. The gemspec has been relaxed to permit upgrades to 1.9.
