### PR TITLE
Add assign_attributes method (as an alias for attributes=)

### DIFF
--- a/lib/mongo_mapper/plugins/accessible.rb
+++ b/lib/mongo_mapper/plugins/accessible.rb
@@ -26,6 +26,10 @@ module MongoMapper
         super(filter_inaccessible_attrs(attrs))
       end
 
+      def assign_attributes(new_attributes, options={})
+        self.attributes=(new_attributes)
+      end
+
       def update_attributes(attrs={})
         super(filter_inaccessible_attrs(attrs))
       end

--- a/test/functional/test_accessible.rb
+++ b/test/functional/test_accessible.rb
@@ -91,6 +91,12 @@ class AccessibleTest < Test::Unit::TestCase
       @doc.admin.should be_false
     end
 
+    should "ignore inaccessible attribute on #assign_attributes" do
+      @doc.assign_attributes({:name => 'Ren Hoek', :admin => true})
+      @doc.name.should == 'Ren Hoek'
+      @doc.admin.should be_false
+    end
+
     should "be indifferent to whether the accessible keys are strings or symbols" do
       @doc.update_attributes!("name" => 'Stimpson J. Cat', "admin" => true)
       @doc.name.should == 'Stimpson J. Cat'


### PR DESCRIPTION
Devise > 2.1.0 uses assign_attributes which is undefined in mongomapper. 

See https://github.com/ianwhite/orm_adapter/issues/21
and http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/DatabaseAuthenticatable#update_with_password-instance_method
