### PR TITLE
Turn embedded callbacks off until a callback is actually defined.

### DIFF
--- a/lib/mongo_mapper/plugins/embedded_callbacks.rb
+++ b/lib/mongo_mapper/plugins/embedded_callbacks.rb
@@ -11,8 +11,8 @@ module MongoMapper
         define_model_callbacks :touch, :only => [:after]
 
         proxy_callbacks(
-          before: [:save, :create, :update, :destroy],
-          after:  [:save, :create, :update, :destroy, :touch]
+          :before => [:save, :create, :update, :destroy],
+          :after  => [:save, :create, :update, :destroy, :touch]
         )
 
         @embedded_callbacks_status = nil


### PR DESCRIPTION
Extracted from #521. Just makes MM not execute embedded callbacks unless one has actually been defined. This speeds up inserts appreciably.

I didn't include the specs for this behavior, as this branch is forked off of master, which doesn't have rspec included. The specs depend on #526 being merged first.
