### PR TITLE
Don't commit associations on assign; defer them until save.

### DIFF
--- a/lib/mongo_mapper/plugins/associations/base.rb
+++ b/lib/mongo_mapper/plugins/associations/base.rb
@@ -4,6 +4,7 @@ module MongoMapper
     module Associations
       class Base
         attr_reader :name, :options, :query_options
+        attr_accessor :dirty
 
         # Options that should not be considered MongoDB query options/criteria
         AssociationOptions = [:as, :class, :class_name, :dependent, :extend, :foreign_key, :in, :polymorphic, :autosave, :touch]
@@ -13,6 +14,7 @@ module MongoMapper
           options.symbolize_keys!
           options[:extend] = modularized_extensions(extension, options[:extend])
           separate_options_and_conditions
+          @dirty = {:self => false, :nullify => []}
         end
 
         def class_name

--- a/lib/mongo_mapper/plugins/associations/base.rb
+++ b/lib/mongo_mapper/plugins/associations/base.rb
@@ -14,7 +14,7 @@ module MongoMapper
           options.symbolize_keys!
           options[:extend] = modularized_extensions(extension, options[:extend])
           separate_options_and_conditions
-          @dirty = {:self => false, :nullify => []}
+          @dirty = {:self => false, :save => [], :nullify => []}
         end
 
         def class_name

--- a/lib/mongo_mapper/plugins/associations/belongs_to_association.rb
+++ b/lib/mongo_mapper/plugins/associations/belongs_to_association.rb
@@ -19,6 +19,17 @@ module MongoMapper
           model.key foreign_key, ObjectId unless model.key?(foreign_key)
           model.key type_key_name, String unless model.key?(type_key_name) if polymorphic?
           super
+
+          association = self
+          model.before_save do
+            association.dirty[:save].each do |doc|
+              doc.save unless doc.persisted?
+            end
+            association.dirty[:save].clear
+
+            true
+          end
+
           add_touch_callbacks if touch?
         end
 

--- a/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
@@ -5,7 +5,7 @@ module MongoMapper
       class BelongsToProxy < Proxy
         def replace(doc)
           if doc
-            doc.save if !doc.persisted?
+            association.dirty[:save] << doc
             id = doc.id
           end
 

--- a/lib/mongo_mapper/plugins/associations/many_association.rb
+++ b/lib/mongo_mapper/plugins/associations/many_association.rb
@@ -40,6 +40,22 @@ module MongoMapper
           association = self
           options = self.options
 
+          model.before_save do
+            proxy = self.get_proxy(association)
+            association.dirty[:save].each do |doc|
+              doc.save
+            end
+            association.dirty[:save].clear
+
+            association.dirty[:nullify].each do |target|
+              proxy.send(:nullify_scope, target)
+              target.save
+            end
+            association.dirty[:nullify].clear
+
+            true
+          end
+
           model.before_destroy do
             if !association.embeddable?
               case options[:dependent]

--- a/lib/mongo_mapper/plugins/associations/many_documents_as_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/many_documents_as_proxy.rb
@@ -9,7 +9,6 @@ module MongoMapper
           end
 
           def apply_scope(doc)
-            ensure_owner_saved
             criteria.each { |key, value| doc[key] = value }
             doc
           end

--- a/lib/mongo_mapper/plugins/associations/one_as_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/one_as_proxy.rb
@@ -7,12 +7,12 @@ module MongoMapper
           def criteria
             {type_key_name => proxy_owner.class.name, id_key_name => proxy_owner.id}
           end
-        
+
         private
           def type_key_name
             "#{options[:as]}_type"
           end
-        
+
           def id_key_name
             "#{options[:as]}_id"
           end

--- a/lib/mongo_mapper/plugins/associations/one_association.rb
+++ b/lib/mongo_mapper/plugins/associations/one_association.rb
@@ -47,6 +47,7 @@ module MongoMapper
               unless proxy.nil?
                 case options[:dependent]
                 when :destroy then proxy.destroy
+                when :delete then proxy.delete
                 else proxy.nullify
                 end
               end

--- a/lib/mongo_mapper/plugins/associations/one_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/one_proxy.rb
@@ -18,23 +18,14 @@ module MongoMapper
         def replace(doc)
           load_target
 
-          if !target.nil? && target != doc
-            if target.persisted?
-              case options[:dependent]
-                when :delete  then target.delete
-                when :destroy then target.destroy
-                else
-                  nullify_scope(target)
-                  target.save
-              end
-            end
+          if !target.nil? && target != doc && target.persisted?
+            association.dirty[:nullify] << target
           end
 
           unless doc.nil?
-            proxy_owner.save unless proxy_owner.persisted?
+            association.dirty[:self] = true
             doc = klass.new(doc) unless doc.is_a?(klass)
             apply_scope(doc)
-            doc.save unless doc.persisted?
           end
 
           loaded

--- a/spec/functional/associations/many_documents_as_proxy_spec.rb
+++ b/spec/functional/associations/many_documents_as_proxy_spec.rb
@@ -35,6 +35,7 @@ describe "ManyDocumentsAsProxy" do
         PostComment.new(:body => 'bar'),
         PostComment.new(:body => 'baz')
       ]
+      post.save
     }.should change { PostComment.count }.by(3)
 
     post = post.reload

--- a/spec/functional/associations/many_documents_proxy_spec.rb
+++ b/spec/functional/associations/many_documents_proxy_spec.rb
@@ -157,74 +157,6 @@ describe "ManyDocumentsProxy" do
         end
       end
 
-      context "=> destroy" do
-        before do
-          @broker_class.many :properties, :class => @property_class, :dependent => :destroy
-
-          @broker = @broker_class.create(:name => "Bob")
-          @property1 = @property_class.create
-          @property2 = @property_class.create
-          @property3 = @property_class.create
-          @broker.properties << @property1
-          @broker.properties << @property2
-          @broker.properties << @property3
-        end
-
-        it "should call destroy the existing documents" do
-          @broker.properties[0].should_receive(:destroy).once
-          @broker.properties[1].should_receive(:destroy).once
-          @broker.properties[2].should_receive(:destroy).once
-          @broker.properties = [@property_class.new]
-        end
-
-        it "should remove the existing document from the database" do
-          @property_class.count.should == 3
-          @broker.properties = []
-          @property_class.count.should == 0
-        end
-
-        it "should skip over documents that are the same" do
-          @broker.properties[0].should_receive(:destroy).never
-          @broker.properties[1].should_receive(:destroy).once
-          @broker.properties[2].should_receive(:destroy).never
-          @broker.properties = [@property3, @property1]
-        end
-      end
-
-      context "=> delete_all" do
-        before do
-          @broker_class.many :properties, :class => @property_class, :dependent => :delete_all
-
-          @broker = @broker_class.create(:name => "Bob")
-          @property1 = @property_class.create
-          @property2 = @property_class.create
-          @property3 = @property_class.create
-          @broker.properties << @property1
-          @broker.properties << @property2
-          @broker.properties << @property3
-        end
-
-        it "should call delete the existing documents" do
-          @broker.properties[0].should_receive(:delete).once
-          @broker.properties[1].should_receive(:delete).once
-          @broker.properties[2].should_receive(:delete).once
-          @broker.properties = [@property_class.new]
-        end
-
-        it "should remove the existing document from the database" do
-          @property_class.count.should == 3
-          @broker.properties = []
-          @property_class.count.should == 0
-        end
-
-        it "should skip over documents that are the same" do
-          @broker.properties[0].should_receive(:delete).never
-          @broker.properties[1].should_receive(:delete).once
-          @broker.properties[2].should_receive(:delete).never
-          @broker.properties = [@property3, @property1]
-        end
-      end
-
       context "=> nullify" do
         before do
           @broker_class.many :properties, :class => @property_class, :dependent => :nullify
@@ -244,6 +176,7 @@ describe "ManyDocumentsProxy" do
           @property3.reload.broker_id.should == @broker.id
 
           @broker.properties = [@property_class.new]
+          @broker.save
 
           @property1.reload.broker_id.should be_nil
           @property2.reload.broker_id.should be_nil
@@ -252,6 +185,7 @@ describe "ManyDocumentsProxy" do
 
         it "should skip over documents that are the same" do
           @broker.properties = [@property3, @property1]
+          @broker.save
 
           @property1.reload.broker_id.should == @broker.id
           @property2.reload.broker_id.should be_nil
@@ -278,6 +212,7 @@ describe "ManyDocumentsProxy" do
           @broker.properties << @property3
 
           @broker.properties = [@property_class.new]
+          @broker.save
 
           @property1.reload.broker_id.should be_nil
           @property2.reload.broker_id.should be_nil

--- a/spec/functional/associations/many_polymorphic_proxy_spec.rb
+++ b/spec/functional/associations/many_polymorphic_proxy_spec.rb
@@ -31,6 +31,7 @@ describe "ManyPolymorphicProxy" do
         Chat.new(:body => 'Heyyyoooo!',         :position => 2),
         Exit.new(:body => 'John exited room',   :position => 3)
       ]
+      room.save
     }.should change { Message.count }.by(3)
 
     room = room.reload

--- a/spec/functional/associations/one_as_proxy_spec.rb
+++ b/spec/functional/associations/one_as_proxy_spec.rb
@@ -288,14 +288,13 @@ describe "OneAsProxy" do
         @post.save
       end
 
-      it "should not call delete the associated documents" do
-        @author_class.any_instance.should_not_receive(:delete)
+      it "should call delete the associated documents" do
+        @author_class.any_instance.should_receive(:delete).once
         @post.destroy
       end
 
-      it "should not remove the associated documents" do
-        @author_class.count.should == 1
-        expect { @post.destroy }.to_not change { @author_class.count }
+      it "should remove the associated documents" do
+        expect { @post.destroy }.to change { @author_class.count }.by( -1 )
         @post.author.should == nil
       end
     end

--- a/spec/functional/associations/one_proxy_spec.rb
+++ b/spec/functional/associations/one_proxy_spec.rb
@@ -200,14 +200,13 @@ describe "OneProxy" do
         @post.save
       end
 
-      it "should not call delete the associated documents" do
-        author_class.any_instance.should_not_receive(:delete)
+      it "should call delete the associated documents" do
+        author_class.any_instance.should_receive(:delete)
         @post.destroy
       end
 
-      it "should not remove the associated documents" do
-        author_class.count.should == 1
-        expect { @post.destroy }.to_not change { author_class.count }
+      it "should remove the associated documents" do
+        expect { @post.destroy }.to change { author_class.count }.by( -1 )
         @post.author.should == nil
       end
     end

--- a/spec/functional/associations/one_proxy_spec.rb
+++ b/spec/functional/associations/one_proxy_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 describe "OneProxy" do
-  before do
-    @post_class = Doc('Post')
-    @author_class = Doc do
-      key :name, String
+  let(:post_class) { Doc('Post') }
+  let(:author_class) {
+    Doc do
+      key :name
       key :post_id, ObjectId
     end
-  end
+  }
 
   it "should default to nil" do
-    @post_class.one :author, :class => @author_class
-    @post_class.new.author.nil?.should be_true
+    post_class.one :author, :class => author_class
+    post_class.new.author.nil?.should be_true
   end
 
   it "should return nil instead of a proxy" do
-    @post_class.one :author, :class => @author_class
-    nil.should === @post_class.new.author
+    post_class.one :author, :class => author_class
+    nil.should === post_class.new.author
   end
 
   it "should allow assignment of associated document using a hash" do
-    @post_class.one :author, :class => @author_class
+    post_class.one :author, :class => author_class
 
-    post = @post_class.new('author' => { 'name' => 'Frank' })
+    post = post_class.new('author' => { 'name' => 'Frank' })
     post.author.name.should == 'Frank'
 
     post.save.should be_true
@@ -34,27 +34,29 @@ describe "OneProxy" do
   context "replacing the association" do
     context "with an object of the class" do
       it "should work" do
-        @post_class.one :author, :class => @author_class
+        post_class.one :author, :class => author_class
 
-        post = @post_class.new
-        author = @author_class.new(:name => 'Frank')
+        post = post_class.new
+        author = author_class.new(:name => 'Frank')
         post.author = author
+        post.save
         post.reload
 
         post.author.should == author
         post.author.nil?.should be_false
 
-        new_author = @author_class.new(:name => 'Emily')
+        new_author = author_class.new(:name => 'Emily')
         post.author = new_author
         post.author.should == new_author
       end
 
       it "should generate a new proxy instead of modifying the existing one" do
-        @post_class.one :author, :class => @author_class
+        post_class.one :author, :class => author_class
 
-        post = @post_class.new
-        author = @author_class.new(:name => 'Frank')
+        post = post_class.new
+        author = author_class.new(:name => 'Frank')
         post.author = author
+        post.save
         post.reload
 
         post.author.should == author
@@ -62,7 +64,7 @@ describe "OneProxy" do
 
         original_author = post.author
         original_author.name.should == 'Frank'
-        new_author = @author_class.new(:name => 'Emily')
+        new_author = author_class.new(:name => 'Emily')
         post.author = new_author
         post.author.should == new_author
 
@@ -72,10 +74,11 @@ describe "OneProxy" do
 
     context "with a Hash" do
       it "should convert to an object of the class and work" do
-        @post_class.one :author, :class => @author_class
+        post_class.one :author, :class => author_class
 
-        post = @post_class.new
+        post = post_class.new
         post.author = {'name' => 'Frank'}
+        post.save
         post.reload
 
         post.author.name.should == 'Frank'
@@ -87,93 +90,19 @@ describe "OneProxy" do
     end
 
     context "with :dependent" do
-      context "=> delete" do
-        before do
-          @post_class.one :author, :class => @author_class, :dependent => :delete
-
-          @post = @post_class.create
-          @author = @author_class.new
-          @post.author = @author
-        end
-
-        it "should call delete on the existing document" do
-          @author_class.any_instance.should_receive(:delete).once
-          @post.author = @author_class.new
-        end
-
-        it "should remove the existing document from the database" do
-          @post.author = @author_class.new
-          lambda { @author.reload }.should raise_error(MongoMapper::DocumentNotFound)
-        end
-
-        it "should do nothing if it's the same document" do
-          @author_class.any_instance.should_receive(:delete).never
-          @post.author = @author
-        end
-      end
-
-      context "=> destory" do
-        before do
-          @post_class.one :author, :class => @author_class, :dependent => :destroy
-
-          @post = @post_class.create
-          @author = @author_class.new
-          @post.author = @author
-        end
-
-        it "should call destroy the existing document" do
-          @author_class.any_instance.should_receive(:destroy).once
-          @post.author = @author_class.new
-        end
-
-        it "should remove the existing document from the database" do
-          @post.author = @author_class.new
-          lambda { @author.reload }.should raise_error(MongoMapper::DocumentNotFound)
-        end
-
-        it "should do nothing if it's the same document" do
-          @author_class.any_instance.should_receive(:destroy).never
-          @post.author = @author
-        end
-      end
-
-      context "=> nullify" do
-        before do
-          @post_class.one :author, :class => @author_class, :dependent => :nullify
-
-          @post = @post_class.create
-          @author = @author_class.new
-          @post.author = @author
-        end
-
-        it "should nullify the existing document" do
-          @author.reload
-          @author.post_id.should == @post.id
-
-          @post.author = @author_class.new
-
-          @author.reload
-          @author.post_id.should be_nil
-        end
-
-        it "should work when it's the same document" do
-          old_author = @post.author
-          @post.author = @author
-          old_author.should == @post.author
-        end
-      end
-
       context "unspecified" do
         it "should nullify the existing document" do
-          @post_class.one :author, :class => @author_class
+          post_class.one :author, :class => author_class
 
-          post = @post_class.create
-          author = @author_class.new
+          post = post_class.create
+          author = author_class.new
           post.author = author
+          post.save
           author.reload
           author.post_id.should == post.id
 
-          post.author = @author_class.new
+          post.author = author_class.new
+          post.save
 
           author.reload
           author.post_id.should be_nil
@@ -183,15 +112,17 @@ describe "OneProxy" do
 
     context "with nil" do
       before do
-        @post_class.one :author, :class => @author_class
+        post_class.one :author, :class => author_class
 
-        @post = @post_class.new
-        @author = @author_class.new(:name => 'Frank')
+        @post = post_class.new
+        @author = author_class.new(:name => 'Frank')
         @post.author = @author
+        @post.save
       end
 
       it "should nullify the existing document" do
         @post.author = nil
+        @post.save
         @author.reload
         @author.post_id.should be_nil
       end
@@ -204,31 +135,31 @@ describe "OneProxy" do
   end
 
   it "should have boolean method for testing presence" do
-    @post_class.one :author, :class => @author_class
+    post_class.one :author, :class => author_class
 
-    post = @post_class.new
+    post = post_class.new
     post.author?.should be_false
 
-    post.author = @author_class.new(:name => 'Frank')
+    post.author = author_class.new(:name => 'Frank')
     post.author?.should be_true
   end
 
   it "should work with criteria" do
-    @post_class.one :primary_author, :class => @author_class, :primary => true
-    @post_class.one :author, :class => @author_class, :primary => false
+    post_class.one :primary_author, :class => author_class, :primary => true
+    post_class.one :author, :class => author_class, :primary => false
 
-    post = @post_class.create
-    author = @author_class.create(:name => 'Frank', :primary => false, :post_id => post.id)
-    primary = @author_class.create(:name => 'Bill', :primary => true, :post_id => post.id)
+    post = post_class.create
+    author = author_class.create(:name => 'Frank', :primary => false, :post_id => post.id)
+    primary = author_class.create(:name => 'Bill', :primary => true, :post_id => post.id)
     post.reload
     post.author.should == author
     post.primary_author.should == primary
   end
 
   it "should unset the association" do
-    @post_class.one :author, :class => @author_class
-    post = @post_class.create
-    author = @author_class.create
+    post_class.one :author, :class => author_class
+    post = post_class.create
+    author = author_class.create
     post.update_attributes!(:author => author)
     post.reload
     post.author = nil
@@ -238,80 +169,83 @@ describe "OneProxy" do
   context "destroying parent with :dependent" do
     context "=> destroy" do
       before do
-        @post_class.one :author, :class => @author_class, :dependent => :destroy
+        post_class.one :author, :class => author_class, :dependent => :destroy
 
-        @post = @post_class.create
-        @author = @author_class.new
+        @post = post_class.create
+        @author = author_class.new
         @post.author = @author
+        @post.save
       end
 
       it "should should call destroy on the associated documents" do
-        @author_class.any_instance.should_receive(:destroy).once
+        author_class.any_instance.should_receive(:destroy).once
         @post.destroy
       end
 
       it "should should remove the associated documents" do
-        @author_class.count.should == 1
+        author_class.count.should == 1
         @post.destroy
         @post.author.should == nil
-        @author_class.count.should == 0
+        author_class.count.should == 0
       end
     end
 
-    context "=> delete" do
+    context "=> :delete" do
       before do
-        @post_class.one :author, :class => @author_class, :dependent => :delete
+        post_class.one :author, :class => author_class, :dependent => :delete
 
-        @post = @post_class.create
-        @author = @author_class.new
+        @post = post_class.create
+        @author = author_class.new
         @post.author = @author
+        @post.save
       end
 
-      it "should should call delete the associated documents" do
-        @author_class.any_instance.should_receive(:delete).once
+      it "should not call delete the associated documents" do
+        author_class.any_instance.should_not_receive(:delete)
         @post.destroy
       end
 
-      it "should remove the associated documents" do
-        @author_class.count.should == 1
-        @post.destroy
+      it "should not remove the associated documents" do
+        author_class.count.should == 1
+        expect { @post.destroy }.to_not change { author_class.count }
         @post.author.should == nil
-        @author_class.count.should == 0
       end
     end
 
     context "=> nullify" do
       it "should should nullify the relationship but not destroy the associated document" do
-        @post_class.one :author, :class => @author_class, :dependent => :nullify
+        post_class.one :author, :class => author_class, :dependent => :nullify
 
-        post = @post_class.create
-        author = @author_class.new
+        post = post_class.create
+        author = author_class.new
         post.author = author
+        post.save
 
-        @author_class.count.should == 1
+        author_class.count.should == 1
         post.destroy
         post.author.should == nil
-        @author_class.count.should == 1
+        author_class.count.should == 1
 
-        @author_class.first.should == author
+        author_class.first.should == author
         author.post_id.should == nil
       end
     end
 
     context "unspecified" do
       it "should should nullify the relationship but not destroy the associated document" do
-        @post_class.one :author, :class => @author_class
+        post_class.one :author, :class => author_class
 
-        post = @post_class.create
-        author = @author_class.new
+        post = post_class.create
+        author = author_class.new
         post.author = author
+        post.save
 
-        @author_class.count.should == 1
+        author_class.count.should == 1
         post.destroy
         post.author.should == nil
-        @author_class.count.should == 1
+        author_class.count.should == 1
 
-        @author_class.first.should == author
+        author_class.first.should == author
         author.post_id.should == nil
       end
     end
@@ -319,14 +253,14 @@ describe "OneProxy" do
 
   context "when building associations" do
     before do
-      @post_class.one :author, :class => @author_class
+      post_class.one :author, :class => author_class
     end
-    let(:post) { @post_class.create }
+    let(:post) { post_class.create }
 
     context "#build" do
       it "should work" do
         author = post.build_author(:name => 'John')
-        post.author.should be_instance_of(@author_class)
+        post.author.should be_instance_of(author_class)
         post.author.should be_new
         post.author.name.should == 'John'
         post.author.should == author
@@ -344,7 +278,7 @@ describe "OneProxy" do
     context "#create" do
       it "should work" do
         author = post.create_author(:name => 'John')
-        post.author.should be_instance_of(@author_class)
+        post.author.should be_instance_of(author_class)
         post.author.should_not be_new
         post.author.name.should == 'John'
         post.author.should == author
@@ -362,7 +296,7 @@ describe "OneProxy" do
 
     context "#create!" do
       before do
-        @author_class.key :name, String, :required => true
+        author_class.key :name, String, :required => true
       end
 
       it "should raise exception if invalid" do
@@ -373,7 +307,7 @@ describe "OneProxy" do
 
       it "should work if valid" do
         author = post.create_author!(:name => 'John')
-        post.author.should be_instance_of(@author_class)
+        post.author.should be_instance_of(author_class)
         post.author.should_not be_new
         post.author.name.should == 'John'
         post.author.should == author
@@ -390,11 +324,14 @@ describe "OneProxy" do
   end
 
   context "namespaced foreign keys" do
-    before do
-      News::Paper.one :article, :class_name => 'News::Article'
-      News::Article.belongs_to :paper, :class_name => 'News::Paper'
+    before do |example|
+      module OneProxySpec; end
+      OneProxySpec::Paper = Class.new(News::Paper)
+      OneProxySpec::Article = Class.new(News::Article)
+      OneProxySpec::Paper.one :article, :class_name => 'OneProxySpec::Article'
+      OneProxySpec::Article.belongs_to :paper, :class_name => 'OneProxySpec::Paper'
 
-      @paper = News::Paper.create
+      @paper = OneProxySpec::Paper.create
     end
 
     it "should properly infer the foreign key" do


### PR DESCRIPTION
This breaks existing functionality, but is probably correct. Since it's not backwards compatible, I wanted @jnunemaker to look it over.

The general problem here is described in #218, and is that assigning associations immediately saves the parent document and the association. This is both surprising and inconsistent with how it's done in other ORMs, and I'd argue that it needs to change.

This fix defers association saves/nullifies until the owner record is saved (but after it is validated!) - this means the deprecation of `:dependent => :delete`. The current implementation makes no sense at all, IMO, since :delete infers "I don't want this model to do its normal teardown". Additionally, this means that assigning an association to nil will not immediately delete the associated record, which is extremely dangerous behavior, IMO - a simple assignment should never destroy data in the database!

The basic fix here is to just defer association commits to `before_save` and eliminate `delete` operating on associated records. Travis is happy with it, but I _did_ remove the specs pertaining to the eliminated behavior to get it there :)

Anyhow, please review and let me know what you think. If the current behavior is there for a reason that I'm not comprehending, I'd love to find a way to improve it.
