### PR TITLE
Bump version to 0.13.0

### DIFF
--- a/lib/mongo_mapper/version.rb
+++ b/lib/mongo_mapper/version.rb
@@ -1,4 +1,4 @@
 # encoding: UTF-8
 module MongoMapper
-  Version = '0.12.0'
+  Version = '0.13.0'
 end


### PR DESCRIPTION
There's support for Rails 4 in `mongomapper` now, but the version never changed. The gem on rubygems is `0.12.0` which didn't support Rails 4, but this would make it possible to build and push a Rails 4-friendly version.
