### PR TITLE
More accurate match, "system.*" is a reserved collection namespace

### DIFF
--- a/lib/mongo_mapper/railtie/database.rake
+++ b/lib/mongo_mapper/railtie/database.rake
@@ -2,7 +2,7 @@ namespace :db do
   unless Rake::Task.task_defined?("db:drop")
     desc 'Drops all the collections for the database for the current Rails.env'
     task :drop => :environment do
-      MongoMapper.database.collections.select {|c| c.name !~ /system/ }.each(&:drop)
+      MongoMapper.database.collections.select {|c| c.name !~ /\Asystem\./ }.each(&:drop)
     end
   end
 


### PR DESCRIPTION
I had troubles with the collection name of `systems`.
Though it is better to avoid such name :P

refs: http://docs.mongodb.org/manual/reference/system-collections/
