### PR TITLE
There is no JRuby version 1.9; this change should avoid confusion

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,7 +23,7 @@ MongoMapper is tested against:
 * MRI 1.8.7
 * MRI 1.9.3
 * MRI 2.0.0
-* JRuby (1.9)
+* JRuby (Versions with 1.9 compatibility)
 
 Additionally, MongoMapper is tested against:
 


### PR DESCRIPTION
Please be more clear when specifying which version of JRuby mongo_mapper is tested against.

I could figure out what you meant, but only after an `rvm get latest` and quick head scratch while wondering how you guys test against 1.9 when JRuby is only on 1.7.
There is no version 1.9; this change should avoid confusion.
