### PR TITLE
Removes trailing whitespace and hard tabs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -30,7 +30,7 @@ Additionally, MongoMapper is tested against:
 * Rails 3.0.x
 * Rails 3.1.x
 * Rails 3.2.x
-* Rails 4.0.x 
+* Rails 4.0.x
 
 NOTE: Rails 4 support is only in the v0.13.0 beta, which is not currently the default in RubyGems.  Use the following line in your gemfile to use the beta:
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ begin
     spec.pattern = 'spec/**/*_spec.rb'
     spec.rspec_opts = ['--color']
   end
-  task :default => :spec  
+  task :default => :spec
 rescue LoadError
   nil
 end

--- a/examples/keys.rb
+++ b/examples/keys.rb
@@ -24,7 +24,7 @@ john = User.create({
   :age        => 28,
   :skills     => ['ruby', 'mongo', 'javascript'],
   :links      => {"Google" => "http://www.google.com"}
-}) 
+})
 
 steve = User.create({
   :first_name => 'Steve',

--- a/examples/modifiers/set.rb
+++ b/examples/modifiers/set.rb
@@ -6,7 +6,7 @@ MongoMapper.database = 'testing'
 
 class User
   include MongoMapper::Document
-  
+
   key :name, String
   key :tags, Array
 end

--- a/examples/querying.rb
+++ b/examples/querying.rb
@@ -6,7 +6,7 @@ MongoMapper.database = 'testing'
 
 class User
   include MongoMapper::Document
-  
+
   key :name, String
   key :tags, Array
 end

--- a/lib/mongo_mapper/plugins/associations/one_as_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/one_as_proxy.rb
@@ -7,12 +7,12 @@ module MongoMapper
           def criteria
             {type_key_name => proxy_owner.class.name, id_key_name => proxy_owner.id}
           end
-        
+
         private
           def type_key_name
             "#{options[:as]}_type"
           end
-        
+
           def id_key_name
             "#{options[:as]}_id"
           end

--- a/lib/mongo_mapper/plugins/callbacks.rb
+++ b/lib/mongo_mapper/plugins/callbacks.rb
@@ -7,7 +7,7 @@ module MongoMapper
       def destroy
         run_callbacks(:destroy) { super }
       end
-      
+
       def touch(*)
         run_callbacks(:touch) { super }
       end

--- a/lib/mongo_mapper/plugins/touch.rb
+++ b/lib/mongo_mapper/plugins/touch.rb
@@ -3,7 +3,7 @@ module MongoMapper
     module Touch
       extend ActiveSupport::Concern
 
-      def touch(key = :updated_at) 
+      def touch(key = :updated_at)
         raise ArgumentError, "Invalid key named #{key}" unless self.key_names.include?(key.to_s)
         if self.class.embeddable?
           self.write_attribute(key, Time.now.utc)

--- a/performance/read_write.rb
+++ b/performance/read_write.rb
@@ -1,4 +1,4 @@
-# The purpose of this is to check finding, initializing, 
+# The purpose of this is to check finding, initializing,
 # and creating objects (typecasting times/dates and booleans).
 
 require 'pp'
@@ -13,7 +13,7 @@ $:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 require 'mongo_mapper'
 
 MongoMapper.database = 'testing'
- 
+
 class Foo
   include MongoMapper::Document
   key :approved, Boolean

--- a/spec/functional/touch_spec.rb
+++ b/spec/functional/touch_spec.rb
@@ -16,7 +16,7 @@ describe "Touch" do
         end
 
         doc.reload
-        doc.updated_at.should_not == old_updated_at      
+        doc.updated_at.should_not == old_updated_at
       end
     end
 
@@ -79,7 +79,7 @@ describe "Touch" do
 
           @post.reload.updated_at.should_not == orig_updated_at
         end
-        
+
         it "should when the child is updated" do
           @comment.save
           old_updated_at = @post.updated_at
@@ -88,7 +88,7 @@ describe "Touch" do
           end
           @post.reload.updated_at.should_not == old_updated_at
         end
-        
+
         it "should when the child is touched" do
           @comment.save
           old_updated_at = @post.updated_at
@@ -117,7 +117,7 @@ describe "Touch" do
         Timecop.freeze(Time.now + 1.day) do
           comment.save
         end
-      
+
         post.reload.updated_at.should == post.created_at
       end
     end

--- a/spec/unit/inspect_spec.rb
+++ b/spec/unit/inspect_spec.rb
@@ -15,7 +15,7 @@ describe "Inspect" do
     it "should print out non-nil attributes in alpha sorted order" do
       @doc.inspect.should =~ /_id:.*, age: 29, name: "John"/
     end
-    
+
     it "should print out all attributes when (optional) include_super argument is true" do
       @doc.inspect(true).should =~ /_id:.*, age: 29, email: nil, name: "John"/
     end
@@ -23,7 +23,7 @@ describe "Inspect" do
     it "should include class name" do
       @doc.inspect.should =~ /^#<User/
     end
-    
+
     it "should include embedded documents" do
       klass = Doc()
       pets = EDoc()
@@ -33,7 +33,7 @@ describe "Inspect" do
       doc = klass.new(:pets => [{:name => "Kitten"}])
       doc.inspect.should =~ /_id:.*, pets: \[.*_id.*, name: "Kitten".*\]/
     end
-    
+
     it "should include embedded document" do
       klass = Doc()
       pet = EDoc()


### PR DESCRIPTION
This commit will remove hard tabs and trailing whitespace from lines throughout the codebase.

In order to reveal offending lines, I used a version of bundler's [quality_spec](https://github.com/bundler/bundler/blob/master/spec/quality_spec.rb).  The spec breaks with more recent versions of rspec, which is the only reason I haven't included the spec itself with this PR.
