### PR TITLE
Adds quality spec

### DIFF
--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -1,0 +1,51 @@
+if defined?(Encoding) && Encoding.default_external != "UTF-8"
+  Encoding.default_external = "UTF-8"
+end
+
+describe "The library itself" do
+  def check_for_tab_characters(filename)
+    failing_lines = []
+    File.readlines(filename).each_with_index do |line,number|
+      failing_lines << number + 1 if line =~ /\t/
+    end
+
+    unless failing_lines.empty?
+      "#{filename} has tab characters on lines #{failing_lines.join(', ')}"
+    end
+  end
+
+  def check_for_extra_spaces(filename)
+    failing_lines = []
+    File.readlines(filename).each_with_index do |line,number|
+      next if line =~ /^\s+#.*\s+\n$/
+      failing_lines << number + 1 if line =~ /\s+\n$/
+    end
+
+    unless failing_lines.empty?
+      "#{filename} has spaces on the EOL on lines #{failing_lines.join(', ')}"
+    end
+  end
+
+  RSpec::Matchers.define :be_well_formed do
+    failure_message_for_should do |actual|
+      actual.join("\n")
+    end
+
+    match do |actual|
+      actual.empty?
+    end
+  end
+
+  it "has no malformed whitespace" do
+    exempt = /\.gitmodules|\.marshal|fixtures|vendor|ssl_certs|kill|LICENSE/
+    error_messages = []
+    Dir.chdir(File.expand_path("../..", __FILE__)) do
+      `git ls-files`.split("\n").each do |filename|
+        next if filename =~ exempt
+        error_messages << check_for_tab_characters(filename)
+        error_messages << check_for_extra_spaces(filename)
+      end
+    end
+    expect(error_messages.compact).to be_well_formed
+  end
+end


### PR DESCRIPTION
Runs with: `rspec spec/quality_spec.rb`

Reveals files & line numbers containing trailing whitespace or hard tabs.
