### PR TITLE
Setting a key using send should return the new value

### DIFF
--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -410,7 +410,6 @@ module MongoMapper
           else
             @_dynamic_attributes[key.name.to_sym] = as_typecast
           end
-          @attributes = nil
         end
 
         def dynamic_key(name)

--- a/spec/functional/keys_spec.rb
+++ b/spec/functional/keys_spec.rb
@@ -24,6 +24,16 @@ describe "Keys" do
     instance.get_foo.should == instance.foo
   end
 
+  it "should return the value when set using send with the writer method" do
+    doc = Doc do
+      key :foo, String
+    end
+
+    instance = doc.new(:foo => 'bar')
+    instance.send("foo=", 'baz').should == 'baz'
+    instance.foo.should == 'baz'
+  end
+
   it "should not bomb if a key is written before Keys#initialize gets to get called" do
     doc = Class.new do
       include MongoMapper::Document


### PR DESCRIPTION
There seems to be an unnecessary line at the end of `internal_write_key`
that results in `send("#{key_name}=", value)` returning nil. This breaks
compatibility with 0.12.

The `@attributes` variable that is set to nil in the last line of
`internal_write_key` does not appear to be
referenced elsewhere.
