### PR TITLE
Proxy#send should work with blocks and procs

### DIFF
--- a/lib/mongo_mapper/plugins/associations/proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/proxy.rb
@@ -91,12 +91,12 @@ module MongoMapper
           proxy_respond_to?(*args) || (load_target && target.respond_to?(*args))
         end
 
-        def send(method, *args)
+        def send(method, *args, &block)
           if proxy_respond_to?(method, true)
             super
           else
             load_target
-            target.send(method, *args)
+            target.send(method, *args, &block)
           end
         end
 

--- a/spec/unit/associations/proxy_spec.rb
+++ b/spec/unit/associations/proxy_spec.rb
@@ -96,5 +96,10 @@ describe "Proxy" do
     it "should not work if neither the proxy or target respond to method" do
       lambda { @proxy.send(:gsub) }.should raise_error
     end
+    
+    it "should work if a proc is passed" do
+      p = Proc.new {|x| x+1}
+      @proxy.send(:collect, &p).should == [2,3]
+    end
   end
 end


### PR DESCRIPTION
I was running into some trouble trying to call a method on the far end of a `belongs_to` relationship and pass a block. For some reason, `Proxy#method_missing` was trying to call `Proxy#send`, at which point the block got lost, and I got a `LocalJumpError: no block given (yield)`. This pull requests seems to fix the issue.
