### PR TITLE
Fix for Document-only Mongo::Connection setup.

### DIFF
--- a/lib/mongo_mapper/plugins/persistence.rb
+++ b/lib/mongo_mapper/plugins/persistence.rb
@@ -16,11 +16,13 @@ module MongoMapper
 
         def connection(mongo_connection=nil)
           assert_supported
-          if mongo_connection.nil? && MongoMapper.connection?
-            @connection ||= MongoMapper.connection
+
+          if mongo_connection.nil?
+            @connection = MongoMapper.connection if @connection.nil?
           else
             @connection = mongo_connection
           end
+
           @connection
         end
 


### PR DESCRIPTION
If you have a Single `MongoMapper::Document` class that sets up its own
`Mongo::Connection` via calling the `#connection` method, _and you have
not_ already set up a global `Mongo::Connection` via
`MongoMapper.connection=` then the first query to that Document will
crash.

This is because when `#database` is called, it calls `#connection` with
no arguments -- on line 44, connection.db(database_name) -- this
ultimately reset the Document's `@connection` ivar to nil, resulting
in the crash.

Instead, I think the `#connection` method should check to see if the
`@connection` ivar has already been set and only set it to
`MongoMapper.connection` _only if_ `@connection` is nil.

This still results in a global localhost connection if the `@connection`
ivar has not previously been set.
