### PR TITLE
write_attribute should return a type casted value

### DIFF
--- a/lib/mongo_mapper/plugins/rails.rb
+++ b/lib/mongo_mapper/plugins/rails.rb
@@ -36,6 +36,7 @@ module MongoMapper
 
       def write_attribute(name, value)
         self[name] = value
+        self[name]
       end
 
       def write_key(name, value)

--- a/spec/unit/rails_spec.rb
+++ b/spec/unit/rails_spec.rb
@@ -66,6 +66,11 @@ describe "Rails integration" do
         @klass.new(:bar => 'Setting Foo').foo.should == 'Setting Foo'
       end
 
+      it "should return the type casted value from write attribute" do
+        obj = @klass.new
+        obj.write_attribute(:foo, true).should == "true"
+      end
+
       context '#to_param' do
         it "should be nil if not persisted" do
           @klass.new.tap do |doc|


### PR DESCRIPTION
write_attribute currently doesn't return the type casted value.  

See this gist:

https://gist.github.com/smtlaissezfaire/e57dfaa90f87d9de7fa9
