### PR TITLE
Updated installation for Rails 4

### DIFF
--- a/documentation/getting-started/rails.textile
+++ b/documentation/getting-started/rails.textile
@@ -12,7 +12,7 @@ First, if you're generating a new Rails application, it is recommended to leave 
 rails new my_app --skip-active-record
 {% endhighlight %}
 
-But, not everyone is starting fresh (a great resource is "here":https://github.com/alindeman/upgradingtorails4). If you're converting an existing Rails application from ActiveRecord (or another ORM), simply open @config/application.rb@ and replace:
+But, not everyone is starting fresh. Andy Lindeman has "an eBook about upgrading from Rails 3 to Rails 4":https://github.com/alindeman/upgradingtorails4. If you're not upgrading, but just converting an existing Rails application from ActiveRecord (or another ORM), simply open @config/application.rb@ and replace:
 
 {% highlight ruby %}
 require 'rails/all'


### PR DESCRIPTION
First time editing textile, any pointers are appreciated (and ways to view locally). This PR updates the installation instructions to add Rails 4. I tested on both 3.2.18 and 4.1.1. The frameworks listed in config/application.rb are from the corresponding new Rails repos (minus active_record/railstie).

https://github.com/mongomapper/mongomapper/issues/573
