### PR TITLE
fixes syntax error in rescue responses

### DIFF
--- a/lib/mongo_mapper/railtie.rb
+++ b/lib/mongo_mapper/railtie.rb
@@ -14,9 +14,9 @@ module MongoMapper
     # Rescue responses similar to ActiveRecord.
     # For rails 3.0 and 3.1
     if Rails.version < "3.2"
-      ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::DocumentNotFound']  = :not_found,
-      ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::InvalidKey']        = :unprocessable_entity,
-      ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::InvalidScheme']     = :unprocessable_entity,
+      ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::DocumentNotFound']  = :not_found
+      ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::InvalidKey']        = :unprocessable_entity
+      ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::InvalidScheme']     = :unprocessable_entity
       ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::NotSupported']      = :unprocessable_entity
     else
       # For rails 3.2 and 4.0


### PR DESCRIPTION
There's a syntax error in the rescue response declarations for rails < 3.2, introduced in cf44aaa523.

It was causing MongoMapper::DocumentNotFound exceptions to cause an exception in WebBrick's exception handling in development. Specifically: 

```
Error during failsafe response: undefined method `to_i' for #<Array:0x007fcab2e7f2f0>
  /Users/bsoule/.rvm/gems/ruby-1.9.3-p448/gems/rack-1.2.8/lib/rack/utils.rb:496:in `status_code'
```

The spurious commas were causing ActionDispatch::ShowExceptions.rescue_responses['MongoMapper::DocumentNotFound'] to get declared as [:not_found, :unprocessable_entity, :unprocessable_entity, :unprocessable_entity], and then rack was choking on it. 
