### PR TITLE
Fix remove_key on activesupport 4.1

### DIFF
--- a/gemfiles/rails4_1.gemfile
+++ b/gemfiles/rails4_1.gemfile
@@ -1,0 +1,4 @@
+eval File.read(File.expand_path('../Gemfile.common', __FILE__)), nil, 'Gemfile.common'
+gemspec :path => '../'
+
+gem 'rails', '~> 4.1.0', :group => :test

--- a/spec/functional/keys_spec.rb
+++ b/spec/functional/keys_spec.rb
@@ -296,4 +296,20 @@ describe "Keys" do
       end
     end
   end
+
+  describe "removing keys" do
+    DocWithRemovedKey = Doc do
+      key :something
+      validates_uniqueness_of :something
+      remove_key :something
+    end
+
+    it 'should remove the key' do
+      DocWithRemovedKey.keys.should_not have_key "_something"
+    end
+
+    it 'should remove validations' do
+      DocWithRemovedKey._validate_callbacks.should be_empty
+    end
+  end
 end


### PR DESCRIPTION
AS::CallbackChain no longer inherits from Array, so we can't just call reject!

As far as I can tell, the only place this is used internally is by set_collection_name (to remove the _type key that could have been added by sci),  but there didn't seem to be any specs for this
