### PR TITLE
Change #first and #last to sort by creation date when using timestamps

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 
 HEAD
 
+  Enhancements:
+
+    * Change #first and #last to return results based on created_at when timestamps are included [smtlaissezfaire]
+
   Internals:
 
     * Changelog updates [smtlaissezfaire]

--- a/lib/mongo_mapper/plugins/timestamps.rb
+++ b/lib/mongo_mapper/plugins/timestamps.rb
@@ -15,6 +15,14 @@ module MongoMapper
           key :updated_at, Time
           class_eval { before_save :update_timestamps }
         end
+
+        def first(options={})
+          super(options.reverse_merge(:order => :created_at))
+        end
+
+        def last(options={})
+          super(options.reverse_merge(:order => :created_at))
+        end
       end
 
       def update_timestamps

--- a/spec/functional/timestamps_spec.rb
+++ b/spec/functional/timestamps_spec.rb
@@ -72,6 +72,31 @@ describe "Timestamps" do
         doc.created_at.to_i.should be_within(1).of(old_created_at.to_i)
         doc.updated_at.to_i.should be_within(1).of(new_updated_at.to_i)
       end
+
+      it "should have #first return the first created object" do
+        doc2 = @klass.create!(:created_at => Time.now)
+        doc1 = @klass.create!(:created_at => 1.week.ago)
+
+        @klass.first.should == doc1
+      end
+
+      it "should have #last return the last created object" do
+        doc2 = @klass.create!(:created_at => Time.now)
+        doc1 = @klass.create!(:created_at => 1.week.ago)
+
+        @klass.last.should == doc2
+      end
+
+      it "should allow sorting by something else" do
+        john = @klass.create!(:first_name => "John", :created_at => 6.months.ago)
+        chris = @klass.create!(:first_name => "Chris", :created_at => 3.weeks.ago)
+
+        @klass.first(:order => :first_name).should == chris
+        @klass.sort(:first_name).first.should == chris
+
+        @klass.last(:order => :first_name).should == john
+        @klass.sort(:first_name).last.should == john
+      end
     end
 
     context "when #record_timestamps is set to false" do


### PR DESCRIPTION
This is something that has always bugged me - Model.first and Model.last will return the same object (not objects sorted by timestamps)
