### PR TITLE
Allowing with_cast to be passed to identity_map.load

### DIFF
--- a/lib/mongo_mapper/plugins/identity_map.rb
+++ b/lib/mongo_mapper/plugins/identity_map.rb
@@ -69,7 +69,7 @@ module MongoMapper
           end
         end
 
-        def load(attrs)
+        def load(attrs, with_cast = false)
           return super unless Thread.current[:mongo_mapper_identity_map_enabled]
           return nil unless attrs
           document = get_from_identity_map(attrs['_id'])

--- a/spec/functional/identity_map_spec.rb
+++ b/spec/functional/identity_map_spec.rb
@@ -178,6 +178,19 @@ describe "IdentityMap" do
         second_load = @person_class.load('_id' => @id, 'name' => 'Frank')
         first_load.should equal(second_load)
       end
+
+      it "should allow passing with_cast" do
+        person_with_time_class = Doc('PersonWithTime') do
+          key :name, String
+          key :created_at, Time
+        end
+
+        expect do
+          loaded = person_with_time_class.load({'_id' => @id, 'name' => 'Frank', 'created_at' => '2014-12-07T20:36:45.529-08:00'}, true)
+          loaded.should be_present
+          loaded.created_at.should be_an_instance_of(Time)
+        end.to_not raise_error
+      end
     end
 
     context "#find (with one id)" do


### PR DESCRIPTION
This simply puts an optional with_cast parameter onto identity_map.load to allow forcing casting when using identity map (for example, to auto-convert strings to Time instance, matching the old default behavior seen in mongomapper 0.12)