### PR TITLE
Fixing failing tests for rails 4

### DIFF
--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -27,7 +27,7 @@ describe "Validations" do
           doc = @document.new
           doc.password = 'foobar'
           doc.password_confirmation = 'foobar1'
-          doc.should have_error_on(:password).or(:password_confirmation)
+          doc.should have_error_on(:password).or(have_error_on(:password_confirmation))
 
           doc.password_confirmation = 'foobar'
           doc.should_not have_error_on(:password)
@@ -320,7 +320,7 @@ describe "Validations" do
           doc = @embedded_doc.new
           doc.password = 'foobar'
           doc.password_confirmation = 'foobar1'
-          doc.should have_error_on(:password).or(:password_confirmation)
+          doc.should have_error_on(:password).or(have_error_on(:password_confirmation))
           doc.password_confirmation = 'foobar'
           doc.should_not have_error_on(:password)
         end


### PR DESCRIPTION
This should fix the Travis CI failures for Rails 4.

However, there are two new failures for Ruby 1.8 related to i18n, since the newest version of i18n apparently requires 1.9.3 or newer: https://github.com/svenfuchs/i18n/blob/v0.7.0/i18n.gemspec#L21 but I'm not sure what the appropriate change is - require an older version of i18n?