### PR TITLE
Fixing all currently failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ gemfile:
   - gemfiles/rails3_2.gemfile
   - gemfiles/rails4_0.gemfile
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.1
@@ -14,10 +13,13 @@ notifications:
 bundler_args: --without development
 services: mongodb
 matrix:
-  exclude:
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails4_0.gemfile
   include:
+    - rvm: 1.8.7
+      gemfile: gemfiles/rails3_0_ruby_1_8_7.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/rails3_1_ruby_1_8_7.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/rails3_2_ruby_1_8_7.gemfile
     - rvm: jruby-19mode
       gemfile: gemfiles/rails3_0.gemfile
       env: JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"

--- a/gemfiles/rails3_0_ruby_1_8_7.gemfile
+++ b/gemfiles/rails3_0_ruby_1_8_7.gemfile
@@ -1,0 +1,6 @@
+eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+gemspec :path => '../'
+
+gem 'rails', '~> 3.0.0', :group => :test
+gem 'i18n', '0.6.11'
+gem 'json'

--- a/gemfiles/rails3_1_ruby_1_8_7.gemfile
+++ b/gemfiles/rails3_1_ruby_1_8_7.gemfile
@@ -1,0 +1,5 @@
+eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+gemspec :path => '../'
+
+gem 'rails', '~> 3.1.0', :group => :test
+gem 'i18n', '0.6.11'

--- a/gemfiles/rails3_2_ruby_1_8_7.gemfile
+++ b/gemfiles/rails3_2_ruby_1_8_7.gemfile
@@ -1,0 +1,5 @@
+eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+gemspec :path => '../'
+
+gem 'rails', '~> 3.2.0', :group => :test
+gem 'i18n', '0.6.11'

--- a/spec/unit/validations_spec.rb
+++ b/spec/unit/validations_spec.rb
@@ -27,7 +27,7 @@ describe "Validations" do
           doc = @document.new
           doc.password = 'foobar'
           doc.password_confirmation = 'foobar1'
-          doc.should have_error_on(:password).or(:password_confirmation)
+          doc.should have_error_on(:password).or(have_error_on(:password_confirmation))
 
           doc.password_confirmation = 'foobar'
           doc.should_not have_error_on(:password)
@@ -320,7 +320,7 @@ describe "Validations" do
           doc = @embedded_doc.new
           doc.password = 'foobar'
           doc.password_confirmation = 'foobar1'
-          doc.should have_error_on(:password).or(:password_confirmation)
+          doc.should have_error_on(:password).or(have_error_on(:password_confirmation))
           doc.password_confirmation = 'foobar'
           doc.should_not have_error_on(:password)
         end


### PR DESCRIPTION
This fixes the two validations_spec tests that are currently failing for all Rails 4 builds.

It also provides one solution for working around the fact that the newest version of i18n gem no longer supports Ruby 1.8 - I added 1.8 specific gemfiles that explicitly specify the latest i18n version that does support Ruby 1.8.