### PR TITLE
uninitialized constant MongoMapper::Railtie::YAML (NameError)

### DIFF
--- a/lib/mongo_mapper/railtie.rb
+++ b/lib/mongo_mapper/railtie.rb
@@ -1,6 +1,7 @@
 require "mongo_mapper"
 require "rails"
 require "active_model/railtie"
+require "yaml"
 
 # Need the action_dispatch railtie to have action_dispatch.rescu_responses initialized correctly
 require "action_dispatch/railtie"


### PR DESCRIPTION
Missing yaml requirement was throwing error on rail 4.2.1: "uninitialized constant MongoMapper::Railtie::YAML (NameError)"
