### PR TITLE
Drop to support systemFlags

### DIFF
--- a/spec/functional/stats_spec.rb
+++ b/spec/functional/stats_spec.rb
@@ -59,10 +59,6 @@ describe "Stats" do
       expect(Docs.stats.padding_factor).to eq(Docs.collection.stats['paddingFactor'])
     end
 
-    it "should have the correct system flags" do
-      expect(Docs.stats.system_flags).to eq(Docs.collection.stats['systemFlags'])
-    end
-
     it "should have the correct user flags" do
       expect(Docs.stats.user_flags).to eq(Docs.collection.stats['userFlags'])
     end


### PR DESCRIPTION
This spec is failed in my MacOS X(Darwin 14.5.0).

```shell
$ mongod --version                                                                                                                                                                    
db version v3.0.6
```

https://jira.mongodb.org/browse/SERVER-20488
https://jira.mongodb.org/browse/SERVER-15625