### PR TITLE
Upgrade to v0.13.2

### DIFF
--- a/lib/mongo_mapper/version.rb
+++ b/lib/mongo_mapper/version.rb
@@ -1,4 +1,4 @@
 # encoding: UTF-8
 module MongoMapper
-  Version = '0.13.1'
+  Version = '0.13.2'
 end


### PR DESCRIPTION
Hey! I would love to use some of the features that have been added to MongoMapper recently, including `default_scopes`. Can you bump the gem version to 0.13.2 and upload a new build of the gem?

Thanks!