### PR TITLE
Fix find! with array of single item

### DIFF
--- a/lib/mongo_mapper/plugins/querying/decorated_plucky_query.rb
+++ b/lib/mongo_mapper/plugins/querying/decorated_plucky_query.rb
@@ -48,10 +48,10 @@ module MongoMapper
         end
 
         def find!(*ids)
-          ids = Array(ids).flatten.uniq
-          raise DocumentNotFound, "Couldn't find without an ID" if ids.size == 0
+          raise DocumentNotFound, "Couldn't find without an ID" if ids.flatten.size == 0
 
           find(*ids).tap do |result|
+            ids = Array(ids).flatten.uniq
             if result.nil? || ids.size != Array(result).size
               raise DocumentNotFound, "Couldn't find all of the ids (#{ids.join(',')}). Found #{Array(result).size}, but was expecting #{ids.size}"
             end

--- a/spec/functional/querying_spec.rb
+++ b/spec/functional/querying_spec.rb
@@ -219,6 +219,16 @@ describe "Querying" do
       end
     end
 
+    context "(with array of single id)" do
+      it "should return an array" do
+        document.find([@doc1._id]).should == [@doc1]
+      end
+
+      it "should return an array for find!" do
+        document.find!([@doc1._id]).should == [@doc1]
+      end
+    end
+
     it "should be able to find using condition auto-detection" do
       document.first(:first_name => 'John').should == @doc1
       document.all(:last_name => 'Nunemaker', :order => 'age desc').should == [@doc1, @doc3]


### PR DESCRIPTION
`find(array)` and `find!(array)` work differently if the array has only ONE item.

`find([id])` will return an array of one item, whereas `find!([id])` will return the item itself, not in an array. This is inconsistent behaviour, and I think that `find!`'s implementation is at fault. It was flattening the array-of-an-array of `*ids` before calling `find`.

The first commit introduces a failing test to highlight the problem.
The second commit fixes the problem.
