### PR TITLE
Add StrongParameters plugin.

### DIFF
--- a/lib/mongo_mapper.rb
+++ b/lib/mongo_mapper.rb
@@ -61,6 +61,7 @@ module MongoMapper
     autoload :Scopes,             'mongo_mapper/plugins/scopes'
     autoload :Serialization,      'mongo_mapper/plugins/serialization'
     autoload :Stats,              'mongo_mapper/plugins/stats'
+    autoload :StrongParameters,   'mongo_mapper/plugins/strong_parameters'
     autoload :Timestamps,         'mongo_mapper/plugins/timestamps'
     autoload :Userstamps,         'mongo_mapper/plugins/userstamps'
     autoload :Validations,        'mongo_mapper/plugins/validations'

--- a/lib/mongo_mapper/plugins/strong_parameters.rb
+++ b/lib/mongo_mapper/plugins/strong_parameters.rb
@@ -1,0 +1,26 @@
+module MongoMapper
+  module Plugins
+    module StrongParameters
+      extend ::ActiveSupport::Concern
+
+      included do
+        include ::ActiveModel::ForbiddenAttributesProtection
+        class << self
+          deprecate :attr_protected, :attr_accessible
+        end
+      end
+
+      def attributes=(attrs = {})
+        super sanitize_for_mass_assignment(attrs)
+      end
+
+      def update_attributes(attrs = {})
+        super sanitize_for_mass_assignment(attrs)
+      end
+
+      def update_attributes!(attrs = {})
+        super sanitize_for_mass_assignment(attrs)
+      end
+    end
+  end
+end

--- a/spec/functional/strong_parameters_spec.rb
+++ b/spec/functional/strong_parameters_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe "Strong parameters" do
+  context 'A document with strong parameters protection' do
+    if ::ActiveModel.const_defined?(:ForbiddenAttributesProtection)
+      require "action_controller/metal/strong_parameters"
+
+      before do
+        @doc_class = Doc do
+          plugin MongoMapper::Plugins::StrongParameters
+
+          key :name, String
+          key :admin, Boolean, :default => false
+        end
+
+        @doc = @doc_class.create(:name => 'Steve Sloan')
+      end
+
+      let(:params) {
+        {name: "Permitted", admin: true}
+      }
+
+      let(:strong_params) {
+        ActionController::Parameters.new params
+      }
+
+      it "allows assignment of attribute hashes" do
+        @doc.attributes = params
+        expect(@doc.name).to eq "Permitted"
+      end
+
+      it "doesn't allow mass assignment of ActionController::Parameters" do
+        expect { @doc.attributes = strong_params }.to raise_error(ActiveModel::ForbiddenAttributesError)
+      end
+
+      it "does not allow mass assignment of non-permitted attributes" do
+        @doc.attributes = strong_params.permit(:name)
+        expect(@doc.admin).to eq false
+      end
+
+      it "allows mass assignment of permitted attributes" do
+        @doc.attributes = strong_params.permit(:name)
+        expect(@doc.name).to eq "Permitted"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ended up needing this, and whipped it up. It's not on by default (since the requisite libs may not be in a particular project) but can be included easily enough via `MongoMapper::Document.plugin MongoMapper::Plugins::StrongParameters`.