### PR TITLE
Fix deprecated use of Fixnum

### DIFF
--- a/lib/mongo_mapper/utils.rb
+++ b/lib/mongo_mapper/utils.rb
@@ -5,7 +5,7 @@ module MongoMapper
       safe = options[:safe]
       safe = {:w => 1} if safe == true
       safe = {:w => 0} if safe == false
-      safe = {:w => safe} if safe.is_a? Fixnum
+      safe = {:w => safe} if safe.is_a? Integer
       safe
     end
   end


### PR DESCRIPTION
Using fixnum in ruby 2.4 generate warnings. change shouldn't have any real world impact (unless someone has a replica set with 2^63 members)