### PR TITLE
Trivial markdown format fix

### DIFF
--- a/documentation/plugins/callbacks.md
+++ b/documentation/plugins/callbacks.md
@@ -7,29 +7,29 @@ MongoMapper makes use of the [ActiveModel::Callbacks](http://api.rubyonrails.org
 
 The callbacks supported are the same as on ActiveModel, the callbacks provided are:
 
-\* before\_validation
-\* after\_validation
-\* before\_save
-\* after\_save
-\* before\_create
-\* after\_create
-\* before\_update
-\* after\_update
-\* before\_destroy
-\* after\_destroy
+* before\_validation
+* after\_validation
+* before\_save
+* after\_save
+* before\_create
+* after\_create
+* before\_update
+* after\_update
+* before\_destroy
+* after\_destroy
 
 For embedded documents you have similar callbacks:
 
-\* before\_validation
-\* after\_validation
-\* before\_save
-\* after\_save
-\* before\_create
-\* after\_create
-\* before\_update
-\* after\_update
-\* before\_destroy
-\* after\_destroy
+* before\_validation
+* after\_validation
+* before\_save
+* after\_save
+* before\_create
+* after\_create
+* before\_update
+* after\_update
+* before\_destroy
+* after\_destroy
 
 Example
 -------


### PR DESCRIPTION
* Before: https://gyazo.com/7d1727349e3ead8bea5cbfbd274368e9
* After: https://gyazo.com/310447afb0e5353f334a6812af1b4f0d (https://ujihisa.github.io/mongomapper/documentation/plugins/callbacks.html is missing CSS but that's not due to this change but simply because it's a fork.)