### PR TITLE
Make active_scopes thread safe

### DIFF
--- a/lib/mongo_mapper/plugins/scopes.rb
+++ b/lib/mongo_mapper/plugins/scopes.rb
@@ -23,7 +23,7 @@ module MongoMapper
         end
 
         def active_scopes
-          @active_scopes ||= []
+          Thread.current["mongo_mapper_#{name}_active_scopes"] ||= []
         end
 
         def default_scopes
@@ -70,12 +70,12 @@ module MongoMapper
           old_active_scopes = active_scopes.dup
 
           @default_scopes = []
-          @active_scopes = []
+          active_scopes.clear
 
           yield
         ensure
           @default_scopes = old_default_scopes
-          @active_scopes = old_active_scopes
+          active_scopes.concat(old_active_scopes)
         end
 
       private


### PR DESCRIPTION
Thank you for maintaining this gem.

I've found `active_scopes` is not thread safe.
It means we can't use this gem with puma, sidekiq and so on.

Actually it seems `default_scopes` is also needed to be fixed though, it's much difficult than fixing `active_scopes`
because `default_scope` method also uses `default_scopes` variable to register scopes.

I'll send another PR to fix `default_scopes` later.