### PR TITLE
Keep the reference to assigned document

### DIFF
--- a/lib/mongo_mapper/plugins/associations/one_embedded_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/one_embedded_proxy.rb
@@ -11,7 +11,9 @@ module MongoMapper
         end
 
         def replace(doc)
-          if doc.respond_to?(:attributes)
+          if doc.instance_of?(klass)
+            @target = doc
+          elsif doc.respond_to?(:attributes)
             @target = klass.load(doc.attributes, true)
           else
             @target = klass.load(doc, true)

--- a/spec/functional/associations/one_embedded_proxy_spec.rb
+++ b/spec/functional/associations/one_embedded_proxy_spec.rb
@@ -97,4 +97,13 @@ describe "OneEmbeddedProxy" do
     post.author.address.id.should_not be_nil
   end
 
+  it "should keep the reference to assigned document" do
+    @post_class.one(:author, :class => @author_class)
+    post = @post_class.new
+    new_author = @author_class.new
+    post.author = new_author
+    new_author.name = 'Frank'
+
+    post.author.name.should == 'Frank'
+  end
 end

--- a/spec/functional/associations/one_proxy_spec.rb
+++ b/spec/functional/associations/one_proxy_spec.rb
@@ -403,4 +403,14 @@ describe "OneProxy" do
       article.paper_id.should == @paper.id
     end
   end
+
+  it "should keep the reference to assigned document" do
+    @post_class.one(:author, :class => @author_class)
+    post = @post_class.new
+    new_author = @author_class.new
+    post.author = new_author
+    new_author.name = 'Frank'
+
+    post.author.name.should == 'Frank'
+  end
 end


### PR DESCRIPTION
Currently, assigning document to embedded one association creates new instance of the document.
As a result, one proxy and embedded one proxy have different behavior:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'pry-byebug'

  gem 'mongo_mapper', '0.15.1'
  gem 'bson_ext'
end

require "minitest/autorun"
MongoMapper.setup({'development' => {'uri' => 'mongodb://mongo/test'}}, 'development', logger: Logger.new(File::NULL))

class Post
  include MongoMapper::Document
  one :author
  one :e_author
end

class Author
  include MongoMapper::Document
  key :name, String
end

class EAuthor
  include MongoMapper::EmbeddedDocument
  key :name, String
end

class BugTest < Minitest::Test
  def test_assingment
    author = Author.new
    e_author = EAuthor.new
    post = Post.new

    post.author = author
    post.e_author = e_author

    author.name = "Frank"
    e_author.name = "Frank"

    assert_equal "Frank", post.author.name
    assert_equal "Frank", post.e_author.name
  end
end
```

As a reference, ActiveRecord behaves like one proxy.

```ruby

require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "activerecord", "6.0.3"
  gem "sqlite3"
  gem "pry-byebug"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(File::NULL)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :authors, force: true do |t|
    t.integer :post_id
    t.text :name
  end
end

class Post < ActiveRecord::Base
  has_one :author
end

class Author < ActiveRecord::Base
  belongs_to :post
end

class BugTest < Minitest::Test
  def test_assignment
    post = Post.new
    author = Author.new
    post.author = author

    author.name = "Frank"

    assert_equal "Frank", post.author.name
  end
end
```

Thus I think we should fix embedded one proxy.