### PR TITLE
Proxy shouldn't respond to private method

### DIFF
--- a/lib/mongo_mapper/plugins/associations/proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/proxy.rb
@@ -136,7 +136,7 @@ module MongoMapper
 
         def method_missing(method, *args, &block)
           if load_target
-            target.send(method, *args, &block)
+            target.public_send(method, *args, &block)
           end
         end
       end

--- a/spec/unit/associations/proxy_spec.rb
+++ b/spec/unit/associations/proxy_spec.rb
@@ -95,5 +95,17 @@ describe "Proxy" do
       p = Proc.new {|x| x+1}
       @proxy.send(:collect, &p).should == [2,3]
     end
+
+    it "should not respond to private method" do
+      @proxy.reload # To load @proxy.target
+      @proxy.target.extend(Module.new do
+        private
+
+          def private_foo
+          end
+      end)
+
+      lambda { @proxy.private_foo }.should raise_error(NoMethodError, /private method `private_foo' called/)
+    end
   end
 end


### PR DESCRIPTION
Perhaps it doesn't matter because belongs_to returns actual object since https://github.com/mongomapper/mongomapper/commit/6dc040490b35e8d201a3617f468b091703bd2d68 though
it seems it should use `public_send`