### PR TITLE
Typecast in-array elements before detecting dirty

### DIFF
--- a/lib/mongo_mapper/plugins/dirty.rb
+++ b/lib/mongo_mapper/plugins/dirty.rb
@@ -38,7 +38,7 @@ module MongoMapper
 
           # typecast to the new value
           old_value = read_key(key_name)
-          new_value = key.type.to_mongo(value)
+          new_value = key.get(key.set(value))
 
           # only mark changed if really changed value (after typecasting)
           unless old_value == new_value

--- a/spec/functional/dirty_spec.rb
+++ b/spec/functional/dirty_spec.rb
@@ -280,6 +280,27 @@ describe "Dirty" do
     end
   end
 
+  context "Document having Array key with typecast option" do
+    before do
+      @author_id = BSON::ObjectId.new
+      @doc = Doc('Book') { key :author_ids, Array, typecast: "ObjectId" }
+      @doc.plugin MongoMapper::Plugins::Dirty
+      @book = @doc.create!(author_ids: [@author_id])
+    end
+
+    context "changed" do
+      it "should be empty if assigned the same array" do
+        @book.author_ids = [@author_id]
+        @book.changed.should be_empty
+      end
+
+      it "should be empty if assigned the same but before-typecasted array" do
+        @book.author_ids = [@author_id.to_s]
+        @book.changed.should be_empty
+      end
+    end
+  end
+
   context "Embedded documents" do
     before do
       @edoc = EDoc('Duck') { key :name, String }


### PR DESCRIPTION
Currently, given an array to `Dirty#write_key()`, it typecasts only the wrapping array with `Array.to_mongo()`, and it doesn't touch its elements.
https://github.com/mongomapper/mongomapper/blob/45b63a30bb344e83a08458ba959b03d0c22591c5/lib/mongo_mapper/plugins/dirty.rb#L41

So it detects a change for an array including before-typecasted elements.

For example, the following test case fails for assigning String ids against ObjectID-typecasted Array key.

```ruby
#!/usr/bin/env ruby

require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "mongo_mapper", "0.15.1"
end

uri = "mongodb://127.0.0.1:27017/test"
logger = Logger.new(File::NULL)
MongoMapper.setup({"development" => {"uri" => uri}}, "development", logger: logger)

class Book
  include MongoMapper::Document
  key :author_ids, Array, typecast: "ObjectId"
end

Book.delete_all

author_id = BSON::ObjectId.new  # BSON::ObjectId
author_id_s = author_id.to_s    # String
book = Book.create!(author_ids: [author_id])

book.author_ids. = [author_id]
raise "book.changed is not empty: #{book.changed}" unless book.changed.empty?
#=> pass

book.author_ids = [author_id_s]
raise "book.changed is not empty: #{book.changed}" unless book.changed.empty?
#=> raise: book.changed is not empty: ["author_ids"] (RuntimeError)
```

Thus, this PR introduces a typecast before detecting changes into `write_key()` as `internal_write_key()`. It should be consistent with its behavior.