### PR TITLE
Update dirty before callbacks

### DIFF
--- a/lib/mongo_mapper/plugins/dirty.rb
+++ b/lib/mongo_mapper/plugins/dirty.rb
@@ -13,7 +13,7 @@ module MongoMapper
         end
       end
 
-      def create_or_update(*)
+      def save_to_collection(*)
         super.tap do
           changes_applied
         end

--- a/spec/functional/dirty_with_callbacks_spec.rb
+++ b/spec/functional/dirty_with_callbacks_spec.rb
@@ -2,21 +2,58 @@ require 'spec_helper'
 
 describe 'DirtyWithCallbacks' do
   it 'should update its changes/previous_changes before after_create/after_update callbacks' do
+    history = {}
+
     document = Doc {
       key :x, String
 
+      after_save {
+        history[:after_save] = {
+          changes: changes,
+          previous_changes: previous_changes,
+        }
+      }
       after_create {
-        changes.should == {}
-        previous_changes.should == {'x' => [nil, 'hello']}
+        history[:after_create] = {
+          changes: changes,
+          previous_changes: previous_changes,
+        }
       }
       after_update {
-        changes.should == {}
-        previous_changes.should == {'x' => ['hello', 'world']}
+        history[:after_update] = {
+          changes: changes,
+          previous_changes: previous_changes,
+        }
       }
     }
 
-    d = document.create(x: 'hello')
+    d = document.new(x: 'hello')
+    d.save
+
+    history.should == {
+      after_save: {
+        changes: {},
+        previous_changes: {'x' => [nil, 'hello']},
+      },
+      after_create: {
+        changes: {},
+        previous_changes: {'x' => [nil, 'hello']},
+      },
+    }
+    history.clear
+
     d.x = 'world'
     d.save!
+
+    history.should == {
+      after_save: {
+        changes: {},
+        previous_changes: {'x' => ['hello', 'world']},
+      },
+      after_update: {
+        changes: {},
+        previous_changes: {'x' => ['hello', 'world']},
+      },
+    }
   end
 end

--- a/spec/functional/dirty_with_callbacks_spec.rb
+++ b/spec/functional/dirty_with_callbacks_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'DirtyWithCallbacks' do
+  it 'should update its changes/previous_changes before after_create/after_update callbacks' do
+    document = Doc {
+      key :x, String
+
+      after_create {
+        changes.should == {}
+        previous_changes.should == {'x' => [nil, 'hello']}
+      }
+      after_update {
+        changes.should == {}
+        previous_changes.should == {'x' => ['hello', 'world']}
+      }
+    }
+
+    d = document.create(x: 'hello')
+    d.x = 'world'
+    d.save!
+  end
+end


### PR DESCRIPTION
* ActiveRecord updates its changes/previous_changes before
  after_create/after_update callbacks
* However, MongoMapper does that after the callbacks, therefore the
  changes/previous_changes values don't match with equivalent code in
  ActiveRecord.

## Comparisons

ActiveRecord:

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'activerecord'
  gem 'sqlite3'
end
require 'active_record'

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(File::NULL)

ActiveRecord::Schema.define do
  create_table :docs, force: true do |t|
    t.text :x
  end
end

class Doc < ActiveRecord::Base
  after_save do
    p changes #=>          {}
    p previous_changes #=> {"id"=>[nil, 1], "x"=>[nil, "hello"]} at create
                       #=> {"x"=>["hello", "world"]} at save!
  end

  after_create do
    p changes #=>          {}
    p previous_changes #=> {"id"=>[nil, 1], "x"=>[nil, "hello"]}
  end

  after_update do
    p changes #=>          {}
    p previous_changes #=> {"x"=>["hello", "world"]}
  end
end

d = Doc.create(x: 'hello')
d.x = 'world'
d.save!
```

MongoMapper:

```ruby
document = Doc {
  key :x, String

  after_save do
    p changes #=>          {}
    p previous_changes #=> {"id"=>[nil, 1], "x"=>[nil, "hello"]} at create
                       #=> {"x"=>["hello", "world"]} at save!
  end
  after_create {
    p changes #=>          {"x"=>[nil, "hello"]}
    p previous_changes #=> {}
  }
  after_update {
    p changes #=>          {"x"=>["hello", "world"]}
    p previous_changes #=> {"x"=>[nil, "hello"]}
  }
}

d = document.create(x: 'hello')
d.x = 'world'
d.save!
```

MongoMapper with this changeset:

```ruby
document = Doc {
  key :x, String

  after_save {
    p changes #=>          {}
    p previous_changes #=> {"x"=>[nil, "hello"]} at create
                       #=> {"x"=>["hello", "world"]} at save
  }
  after_create {
    p changes #=>          {}
    p previous_changes #=> {"x"=>[nil, "hello"]}
  }
  after_update {
    p changes #=>          {}
    p previous_changes #=> {"x"=>["hello", "world"]}
  }
}

d = document.new(x: 'hello')
d.save
d.x = 'world'
d.save!
```

The only difference between the new behaviour and ActiveRecord is to show `id` in `previous_changes` or not. Since the behaviour for IDs are already different between MongoMapper and ActiveRecord, I kept it as is, but if it makes more sense I'm also happy to work on adding `_id` into the `previous_changes`.