### PR TITLE
Prohibit defining some scope names that overrides existing methods, such as "private"

### DIFF
--- a/lib/mongo_mapper/plugins/scopes.rb
+++ b/lib/mongo_mapper/plugins/scopes.rb
@@ -107,7 +107,7 @@ module MongoMapper
 
         def dangerous_class_method?(method_name)
           return true if RESTRICTED_CLASS_METHODS.include?(method_name.to_s)
-          Document.method_defined?(method_name, true)
+          Document.method_defined?(method_name)
         end
       end
     end

--- a/spec/functional/scopes_spec.rb
+++ b/spec/functional/scopes_spec.rb
@@ -200,6 +200,19 @@ describe "Scopes" do
         Blog.scopes.keys.map(&:to_s).should =~ %w(by_slug by_title published)
       end
     end
+
+    context 'with predefined class method name' do
+      it 'should raise ArgumentError' do
+        bad_names = %i(private public protected allocate new name parent superclass reload)
+        bad_names.each do |bad_name|
+          -> {
+            Doc() do
+              scope bad_name, -> {}
+            end
+          }.should raise_error(ArgumentError, /You tried to define a scope named "#{bad_name}"/)
+        end
+      end
+    end
   end
 
   describe "with_scope" do


### PR DESCRIPTION
* Problem: When you define a scope `scope :private, -> {...}`, it overrides
  `Module.private`, so you won't be able to define private methods.
    * The same thing would happen for other dangerous names, such as
      "private", "new", or "reload"
* Solution: Like ActiveRecord, raise ArgumentError immediately when you define
  a scope that matches with one in predefined some dangerous methods.
    * https://github.com/rails/rails/blob/600132afc17453019772d7065b0dde0ff408503a/activerecord/lib/active_record/scoping/named.rb#L159
    * https://github.com/rails/rails/blob/d04f74dd7271c477a6fb01c57bdc08eec48adc19/activerecord/lib/active_record/attribute_methods.rb#L125
    * Note that ActiveRecord::Base is a class whilst MongoMapper::Document is a
      module, this commit look slightly different to ActiveRecord's solution.