### PR TITLE
Avoid caching _root_document

### DIFF
--- a/lib/mongo_mapper/plugins/embedded_document.rb
+++ b/lib/mongo_mapper/plugins/embedded_document.rb
@@ -46,7 +46,7 @@ module MongoMapper
       end
 
       def _root_document
-        @_root_document ||= _parent_document.try(:_root_document)
+        _parent_document.try(:_root_document)
       end
     end
   end

--- a/spec/functional/associations/one_embedded_proxy_spec.rb
+++ b/spec/functional/associations/one_embedded_proxy_spec.rb
@@ -106,4 +106,23 @@ describe "OneEmbeddedProxy" do
 
     post.author.name.should == 'Frank'
   end
+
+  it "should update references for parent and root" do
+    @post_class.key(:author_name, String)
+    @post_class.one(:author, :class => @author_class)
+    @post_class.before_save do
+      self.author_name = author.name
+    end
+
+    author = @author_class.new
+    @post_class.create!(author: author)
+    author.save!
+
+    post = @post_class.create!(author: author)
+    post.author.name = 'Frank'
+    post.author.save!
+
+    post.author.name.should == 'Frank'
+    post.author_name.should == 'Frank'
+  end
 end


### PR DESCRIPTION
0.15.1 passes the following test but latest doesn't.

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'pry-byebug'

  gem 'bson_ext'
  if ENV['LATEST_MM']
    gem 'mongo_mapper', git: 'https://github.com/mongomapper/mongomapper.git'
  else
    gem 'mongo_mapper', '0.15.1'
  end
end

require "minitest/autorun"
MongoMapper.setup({'development' => {'uri' => 'mongodb://mongo/test'}}, 'development', logger: Logger.new(File::NULL))

class Post
  include MongoMapper::Document
  key :author_name, String
  one :author

  before_save do
    if author
      self.author_name = author.name
    end
  end
end

class Author
  include MongoMapper::EmbeddedDocument

  key :name, String

  embedded_in :post
end

class BugTest < Minitest::Test
  def test_xxx
    author = Author.new
    Post.create!(author: author)
    author.save!

    post = Post.create!(author: author)
    post.author.name = "alice"
    post.author.save!

    assert_equal "alice", post.author_name
    #  1) Failure:
    # BugTest#test_xxx [aaa.rb:49]:
    # Expected: "alice"
    #   Actual: nil
  end
end
```

It's because of my PR, sorry.
https://github.com/mongomapper/mongomapper/pull/664

_parent_document is updated via assign_references but _root_document isn't.

https://github.com/mongomapper/mongomapper/blob/fedd68e25516703c6cf8baae7f992060af098fa3/lib/mongo_mapper/plugins/associations/one_embedded_proxy.rb#L21

Before merging #664, it doesn't matter because `@target` is a new instance of the doc.