### PR TITLE
Specify Rails' minor version in CI

### DIFF
--- a/gemfiles/rails5_0.gemfile
+++ b/gemfiles/rails5_0.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 5.0', :group => :test
+gem 'rails', '~> 5.0.0', :group => :test

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 5.1', :group => :test
+gem 'rails', '~> 5.1.0', :group => :test

--- a/gemfiles/rails5_2.gemfile
+++ b/gemfiles/rails5_2.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 5.2', :group => :test
+gem 'rails', '~> 5.2.0', :group => :test

--- a/gemfiles/rails6_0.gemfile
+++ b/gemfiles/rails6_0.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 6.0', :group => :test
+gem 'rails', '~> 6.0.0', :group => :test

--- a/gemfiles/rails6_1.gemfile
+++ b/gemfiles/rails6_1.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 6.1', group: :test
+gem 'rails', '~> 6.1.0', group: :test


### PR DESCRIPTION
This PR updates gemfiles to install rails whose version matches with their filenames.
For example, gemfiles/rails5_0.gemfile should install rails 5.0, but it installs rails 5.2 now.