### PR TITLE
Add CRuby 3.0.0 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
         - jruby
@@ -18,17 +20,38 @@ jobs:
         - 2.6.6
         - 2.7.1
         - 2.7.2
+        - 3.0.0
         gemfile:
         - gemfiles/rails5_0.gemfile
         - gemfiles/rails5_1.gemfile
         - gemfiles/rails5_2.gemfile
         - gemfiles/rails6_0.gemfile
         - gemfiles/rails6_1.gemfile
+        experimental:
+        - false
         exclude:
           - ruby-version: 2.4.10
             gemfile: gemfiles/rails6_0.gemfile
+            experimental: false
           - ruby-version: 2.4.10
             gemfile: gemfiles/rails6_1.gemfile
+            experimental: false
+        include:
+          - ruby-version: head
+            gemfile: gemfiles/rails5_0.gemfile
+            experimental: true
+          - ruby-version: head
+            gemfile: gemfiles/rails5_1.gemfile
+            experimental: true
+          - ruby-version: head
+            gemfile: gemfiles/rails5_2.gemfile
+            experimental: true
+          - ruby-version: head
+            gemfile: gemfiles/rails6_0.gemfile
+            experimental: true
+          - ruby-version: head
+            gemfile: gemfiles/rails6_1.gemfile
+            experimental: true
     env:
       JRUBY_OPTS: "--1.9"
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"


### PR DESCRIPTION
This PR updates CI to test against ruby 3.0.0, and introduces introduces the `continue-on-error` option so we can merge a PR even if a spec fails against 3.0.0.

Note that, however, the result will be shown as the following if it's unsuccessful.
![image](https://user-images.githubusercontent.com/98728/102198963-60201100-3f06-11eb-8415-a1ad0b6556dd.png)

The so-called `allow-failure` option hasn't been supported in GitHub Actions yet.
https://github.com/actions/toolkit/issues/399

If you think it's not good for our development, please let me know that.
Thanks!