### PR TITLE
Reload belongs to association when foreign key is changed

### DIFF
--- a/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
@@ -47,6 +47,12 @@ module MongoMapper
           loaded
           @target
         end
+
+      private
+
+        def stale_target?
+          loaded? && @target && proxy_owner[association.foreign_key] != @target.id
+        end
       end
     end
   end

--- a/lib/mongo_mapper/plugins/associations/proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/proxy.rb
@@ -107,7 +107,7 @@ module MongoMapper
       protected
 
         def load_target
-          unless loaded?
+          if !loaded? || stale_target?
             if @target.is_a?(Array) && @target.any?
               @target = find_target + @target.find_all { |record| !record.persisted? }
             else
@@ -133,6 +133,10 @@ module MongoMapper
         end
 
       private
+
+        def stale_target?
+          false
+        end
 
         def method_missing(method, *args, &block)
           if load_target

--- a/spec/functional/associations/belongs_to_proxy_spec.rb
+++ b/spec/functional/associations/belongs_to_proxy_spec.rb
@@ -269,4 +269,22 @@ describe "BelongsToProxy" do
       end.should_not raise_error
     end
   end
+
+  context "foreign_key=" do
+    it "should reset parent when foreign key is changed" do
+      post = @post_class.create!
+      comment = @comment_class.create!(post: post)
+      another_post = @post_class.create!
+
+      comment.post.should == post
+
+      comment.post_id = another_post.id
+
+      comment.post.should == another_post
+
+      comment.post_id = nil
+
+      comment.post.should == nil
+    end
+  end
 end


### PR DESCRIPTION
Currently, mongomapper doesn't reload object when foreign key is changed:

```ruby
post = Post.create!
author1 = Author.create!
author2 = Author.create!

post.author_id = author1.id

assert_equal author1, post.author

post.author_id = author2.id

assert_equal author2, post.author
# --- expected
# +++ actual
# @@ -1 +1 @@
# -#<Author _id: BSON::ObjectId('6006bf4a434b7330940c0bec')>
# +#<Author _id: BSON::ObjectId('6006bf4a434b7330940c0beb')>
```

<details>
<summary> full code</summary>

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'mongo_mapper', '0.15.1'
  gem 'bson_ext'
end

require "minitest/autorun"
MongoMapper.setup({'development' => {'uri' => 'mongodb://mongo/test'}}, 'development', logger: Logger.new(File::NULL))

class Post
  include MongoMapper::Document

  belongs_to :author
end

class Author
  include MongoMapper::Document

  key :name, String
end

class BugTest < Minitest::Test
  def test_xxx
    post = Post.create!
    author1 = Author.create!
    author2 = Author.create!

    post.author_id = author1.id

    assert_equal author1, post.author

    post.author_id = author2.id

    assert_equal author2, post.author
  end
end

__END__
Run options: --seed 26312

# Running:

F

Finished in 0.015940s, 62.7360 runs/s, 125.4721 assertions/s.

  1) Failure:
BugTest#test_xxx [x.rb:39]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Author _id: BSON::ObjectId('6006bf4a434b7330940c0bec')>
+#<Author _id: BSON::ObjectId('6006bf4a434b7330940c0beb')>


1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```
</details>