### PR TITLE
Reload proxy target for stale nil target

### DIFF
--- a/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
+++ b/lib/mongo_mapper/plugins/associations/belongs_to_proxy.rb
@@ -51,7 +51,7 @@ module MongoMapper
       private
 
         def stale_target?
-          loaded? && @target && proxy_owner[association.foreign_key] != @target.id
+          loaded? && proxy_owner[association.foreign_key] != @target&.id
         end
       end
     end

--- a/spec/functional/associations/belongs_to_proxy_spec.rb
+++ b/spec/functional/associations/belongs_to_proxy_spec.rb
@@ -286,5 +286,20 @@ describe "BelongsToProxy" do
 
       comment.post.should == nil
     end
+
+    it "should reset parent when foreign key is changed from nil" do
+      post = @post_class.create!
+      comment = @comment_class.create!(post: nil)
+
+      comment.post.should == nil
+
+      comment.post_id = post.id
+
+      comment.post.should == post
+
+      comment.post_id = nil
+
+      comment.post.should == nil
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,13 @@ $:.unshift(File.expand_path('../../lib', __FILE__))
 
 require 'rubygems'
 require 'bundler/setup'
+
+# workaround for https://github.com/jruby/jruby/issues/6547
+if RUBY_PLATFORM == 'java'
+  require 'i18n/backend'
+  require 'i18n/backend/simple'
+end
+
 Bundler.require(:default)
 require 'fileutils'
 require 'timecop'


### PR DESCRIPTION
## Overview

Since 0.15.1, belongs_to association holds  nil target even if its foreign key is changed:

```ruby
child = Child.create!(parent: nil)
child.parent_id = Parent.create!.id
p child.parent #=> nil
```

To refresh the nil target, this commit patches `stale_target?` to compare the loaded target's id and the foreign key in the attributes hash **including nil**.

Here is reproducible code and its result:

```ruby
# test.rb
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "mongo_mapper", ENV.fetch("MM_VERSION")

  if Gem::Version.new(ENV.fetch("MM_VERSION")) < Gem::Version.new("0.15.0")
    gem "activemodel-serializers-xml"
    gem "activemodel", "5.1"
    gem "bson_ext"
  end
end

MongoMapper.setup({"development" => {"uri" => "mongodb://localhost:27017/test"}}, "development")

class Parent
  include MongoMapper::Document
  one :child
end

class Child
  include MongoMapper::Document
  belongs_to :parent
end

child = Child.create!(parent: nil)
child.parent_id = Parent.create!.id
p child.parent
```

```console
$ MM_VERSION=0.15.2 ruby test.rb
nil
$ MM_VERSION=0.15.1 ruby test.rb
nil
$ MM_VERSION=0.15.0 ruby test.rb
#<Parent _id: BSON::ObjectId('601d14136d02873e950b4086')>
```

## Why this happens

In short, it is because updating the foreign key doesn't update `@loaded` from true and `@target` from nil which are set by `child.parent = nil` called in`Child.create!(parent: nil)`.

I found that https://github.com/mongomapper/mongomapper/commit/6dc040490b35e8d201a3617f468b091703bd2d68 caused this issue.

Before the commit, 

1. `child.parent = nil` just resets `@loaded` to false and `@target` to nil in BelongsToProxy#replace, and keep them so by returning given `nil` directly
1. `child.parent_id = Parent.create!.id` doesn't touch them
1. `p child.parent` loads the Parent document with the parent_id and returns it. This is because `@loaded` is left nil since 1.

However, after the commit, 

1. `child.parent = nil` resets `@loaded` to false and `@target` to nil in BelongsToProxy#replace, and updates `@loaded` to true and `@target` to nil in `proxy.read`
1. `child.parent_id = Parent.create!.id` doesn't touch them. This is the same as the above
1. `p child.parent` returns `@target == nil`. This is because `@loaded` is left true since 1. Also, `sale_target?` introduced in 0.15.2 doesn't work in this case for `@target == nil` is falsy.

So I patched `stale_target?` to compare nil foreign keys.

## Another solution, but seems difficult

It is to patch `write_key` to reset `@loaded` and `@target` on updating a foreign key for a belongs_to association.

However, the method is used widely in internal, and we have to care when reset happens more carefully.
So I updated `stale_target?` to fix the issue.