### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,6 +37,8 @@ jobs:
             gemfile: gemfiles/rails5_1.gemfile
           - ruby-version: 3.0.0
             gemfile: gemfiles/rails5_2.gemfile
+          - ruby-version: 3.0.0
+            gemfile: gemfiles/rails6_0.gemfile
     env:
       JRUBY_OPTS: "--1.9"
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - jruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,18 +12,18 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - jruby
-        - 2.4.10
-        - 2.5.8
-        - 2.6.6
-        - 2.7.1
-        - 2.7.2
+          - jruby
+          - 2.4.10
+          - 2.5.8
+          - 2.6.6
+          - 2.7.1
+          - 2.7.2
         gemfile:
-        - gemfiles/rails5_0.gemfile
-        - gemfiles/rails5_1.gemfile
-        - gemfiles/rails5_2.gemfile
-        - gemfiles/rails6_0.gemfile
-        - gemfiles/rails6_1.gemfile
+          - gemfiles/rails5_0.gemfile
+          - gemfiles/rails5_1.gemfile
+          - gemfiles/rails5_2.gemfile
+          - gemfiles/rails6_0.gemfile
+          - gemfiles/rails6_1.gemfile
         exclude:
           - ruby-version: 2.4.10
             gemfile: gemfiles/rails6_0.gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,6 +18,7 @@ jobs:
           - 2.6.6
           - 2.7.1
           - 2.7.2
+          - 3.0.0
         gemfile:
           - gemfiles/rails5_0.gemfile
           - gemfiles/rails5_1.gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,6 +31,12 @@ jobs:
             gemfile: gemfiles/rails6_0.gemfile
           - ruby-version: 2.4.10
             gemfile: gemfiles/rails6_1.gemfile
+          - ruby-version: 3.0.0
+            gemfile: gemfiles/rails5_0.gemfile
+          - ruby-version: 3.0.0
+            gemfile: gemfiles/rails5_1.gemfile
+          - ruby-version: 3.0.0
+            gemfile: gemfiles/rails5_2.gemfile
     env:
       JRUBY_OPTS: "--1.9"
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"

--- a/gemfiles/rails5_0.gemfile
+++ b/gemfiles/rails5_0.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 5.0', :group => :test
+gem 'rails', '~> 5.0.0', :group => :test

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 5.1', :group => :test
+gem 'rails', '~> 5.1.0', :group => :test

--- a/gemfiles/rails5_2.gemfile
+++ b/gemfiles/rails5_2.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 5.2', :group => :test
+gem 'rails', '~> 5.2.0', :group => :test

--- a/gemfiles/rails6_0.gemfile
+++ b/gemfiles/rails6_0.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 6.0', :group => :test
+gem 'rails', '~> 6.0.0', :group => :test

--- a/gemfiles/rails6_1.gemfile
+++ b/gemfiles/rails6_1.gemfile
@@ -1,4 +1,4 @@
 eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
 gemspec :path => '../'
 
-gem 'rails', '~> 6.1', group: :test
+gem 'rails', '~> 6.1.0', group: :test

--- a/lib/mongo_mapper/plugins/validations.rb
+++ b/lib/mongo_mapper/plugins/validations.rb
@@ -54,7 +54,7 @@ module MongoMapper
           conditions[:_id.ne] = record._id if record._id
 
           if @klass.exists?(conditions)
-            record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
+            record.errors.add(attribute, :taken, **options.except(:case_sensitive, :scope).merge(:value => value))
           end
         end
 

--- a/mongo_mapper.gemspec
+++ b/mongo_mapper.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 5.0'
   s.add_dependency 'activemodel',   ">= 5.0"
   s.add_dependency 'activemodel-serializers-xml', "~> 1.0"
+
+  s.add_dependency 'rexml'
 end


### PR DESCRIPTION
This PR adds Ruby 3.0 support and some improvements in CI.
Note that Rails 5.2 or less doesn't support Ruby 3.0 as described at  https://github.com/rails/rails/issues/40938, so I excluded them from the CI matrix.

Currently, JSON serialization with Rails 6.0 and Ruby 3.0 seems broken and the CI fails. I reported the issue at https://github.com/rails/rails/issues/41554. Until the issue gets fixed, we can't pass the CI. So I tagged "WIP" in the subject.