### PR TITLE
Forbid keys with the same name of internal method

### DIFF
--- a/lib/mongo_mapper.rb
+++ b/lib/mongo_mapper.rb
@@ -94,6 +94,45 @@ module MongoMapper
     end
   end
 
+  DOCUMENT_MODULES = [
+    MongoMapper::Plugins::Accessible,
+    MongoMapper::Plugins::ActiveModel,
+    MongoMapper::Plugins::Associations,
+    MongoMapper::Plugins::Caching,
+    MongoMapper::Plugins::Callbacks,
+    MongoMapper::Plugins::Clone,
+    MongoMapper::Plugins::CounterCache,
+    MongoMapper::Plugins::Dirty,
+    MongoMapper::Plugins::Document,
+    MongoMapper::Plugins::Dumpable,
+    MongoMapper::Plugins::DynamicQuerying,
+    MongoMapper::Plugins::EmbeddedCallbacks,
+    MongoMapper::Plugins::EmbeddedDocument,
+    MongoMapper::Plugins::Equality,
+    MongoMapper::Plugins::IdentityMap,
+    MongoMapper::Plugins::Indexes,
+    MongoMapper::Plugins::Inspect,
+    MongoMapper::Plugins::Keys,
+    MongoMapper::Plugins::Keys::Static,
+    MongoMapper::Plugins::Logger,
+    MongoMapper::Plugins::Modifiers,
+    MongoMapper::Plugins::Pagination,
+    MongoMapper::Plugins::PartialUpdates,
+    MongoMapper::Plugins::Persistence,
+    MongoMapper::Plugins::Protected,
+    MongoMapper::Plugins::Querying,
+    MongoMapper::Plugins::Rails,
+    MongoMapper::Plugins::Safe,
+    MongoMapper::Plugins::Sci,
+    MongoMapper::Plugins::Scopes,
+    MongoMapper::Plugins::Serialization,
+    MongoMapper::Plugins::Stats,
+    MongoMapper::Plugins::Timestamps,
+    MongoMapper::Plugins::Touch,
+    MongoMapper::Plugins::Userstamps,
+    MongoMapper::Plugins::Validations,
+  ].freeze
+
   extend Connection
 end
 

--- a/lib/mongo_mapper/plugins/keys/key.rb
+++ b/lib/mongo_mapper/plugins/keys/key.rb
@@ -8,6 +8,12 @@ module MongoMapper
 
         attr_accessor :name, :type, :options, :default, :ivar, :abbr, :accessors
 
+        def self.reserved_names
+          @reserved_names ||= MongoMapper::DOCUMENT_MODULES.flat_map { |klass|
+            klass.instance_methods.map(&:to_s)
+          }.uniq + RESERVED_KEYS
+        end
+
         def initialize(*args)
           options_from_args = args.extract_options!
           @name, @type = args.shift.to_s, args.shift
@@ -103,7 +109,9 @@ module MongoMapper
         end
 
         def reserved_name?
-          RESERVED_KEYS.include?(@name)
+          [@name, "#{@name}_before_typecast", "#{@name}=", "#{@name}?"].any? { |name|
+            self.class.reserved_names.include?(name)
+          }
         end
 
         def read_accessor?

--- a/spec/unit/key_spec.rb
+++ b/spec/unit/key_spec.rb
@@ -61,6 +61,17 @@ describe "Key" do
 
     it "should not permit reserved names" do
       lambda { Key.new(:id) }.should raise_error(/reserved/)
+      lambda { Key.new(:valid) }.should raise_error(/reserved/)
+    end
+
+    it "should permit reserved names if __dynamic" do
+      lambda { Key.new(:id, :__dynamic => true) }.should_not raise_error
+      lambda { Key.new(:valid, :__dynamic => true) }.should_not raise_error
+    end
+
+    it "should permit reserved names if it is not to create accessors" do
+      lambda { Key.new(:id, :accessors => :skip) }.should_not raise_error
+      lambda { Key.new(:valid, :accessors => :skip) }.should_not raise_error
     end
 
     it "should not permit bad names" do


### PR DESCRIPTION
Hi 👋 

This PR introduces a key name validation against internal methods.
It would make accessor methods' behavior more understandable.

For example, we can use `valid` as a key name, and it defines `valid?` method with `accessors: :predicate` option. However, it is overridden by `MongoMapper::Plugins::Validations#valid?`.

```ruby
class User
  include MongoMapper::Document

  key :valid, Boolean, accessors: :predicate
end

user = User.new(valid: false)
p user.valid  #=> false
p user.valid? #=> true
```

So this PR adds internal method names to reserved names and validates accessor names for a key (i.g., `#{name}?`) against them.

This change can break compatibility, so it may be good to add an option to enable the validation. I'd be happy to hear your opinions. 

Thanks!