### PR TITLE
Add Rails 6.0 w/ Ruby 3.0 to CI matrix again

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,8 +37,6 @@ jobs:
             gemfile: gemfiles/rails5_1.gemfile
           - ruby-version: 3.0.0
             gemfile: gemfiles/rails5_2.gemfile
-          - ruby-version: 3.0.0
-            gemfile: gemfiles/rails6_0.gemfile
     env:
       JRUBY_OPTS: "--1.9"
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"


### PR DESCRIPTION
Rails 6.0.4 has been released and includes a fix for our CI.
https://weblog.rubyonrails.org/2021/6/15/Rails-6-0-4-has-been-released/
https://github.com/mongomapper/mongomapper/pull/680