### PR TITLE
Support Rails 7.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,11 +27,18 @@ jobs:
           - gemfiles/rails5_2.gemfile
           - gemfiles/rails6_0.gemfile
           - gemfiles/rails6_1.gemfile
+          - gemfiles/rails7_0.gemfile
         exclude:
+          - ruby-version: 2.4.10
+            gemfile: gemfiles/rails7_0.gemfile
           - ruby-version: 2.4.10
             gemfile: gemfiles/rails6_0.gemfile
           - ruby-version: 2.4.10
             gemfile: gemfiles/rails6_1.gemfile
+          - ruby-version: 2.5.8
+            gemfile: gemfiles/rails7_0.gemfile
+          - ruby-version: 2.6.6
+            gemfile: gemfiles/rails7_0.gemfile
           - ruby-version: 3.0.0
             gemfile: gemfiles/rails5_0.gemfile
           - ruby-version: 3.0.0

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,6 +29,8 @@ jobs:
           - gemfiles/rails6_1.gemfile
           - gemfiles/rails7_0.gemfile
         exclude:
+          - ruby-version: jruby
+            gemfile: gemfiles/rails7_0.gemfile
           - ruby-version: 2.4.10
             gemfile: gemfiles/rails7_0.gemfile
           - ruby-version: 2.4.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Doc Fixes:
 -->
 
+## Unreleased
+### Enhancements:
+
+* PR-687 Masato Ikeda <masato.ikeda@gmail.com> Support Rails 7.0
+
 ## 0.15.4 - 2021-06-18
 ### Enhancements:
 

--- a/gemfiles/rails7_0.gemfile
+++ b/gemfiles/rails7_0.gemfile
@@ -1,0 +1,4 @@
+eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+gemspec :path => '../'
+
+gem 'rails', '~> 7.0.0', group: :test

--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -251,12 +251,24 @@ module MongoMapper
 
         def remove_validate_callbacks(a_name)
           chain = _validate_callbacks.dup.reject do |callback|
-            f = callback.raw_filter
+            f = callback_filter(callback)
             f.respond_to?(:attributes) && f.attributes == a_name
           end
           reset_callbacks(:validate)
           chain.each do |callback|
-            set_callback 'validate', callback.raw_filter
+            set_callback 'validate', callback_filter(callback)
+          end
+        end
+
+        # The interface to obtain @filter from ActiveSupport::Callbacks::Callback has changed since rails 7.0.
+        # https://github.com/rails/rails/commit/d5ac941ddc3de7ad1aaff80ed67aa04fb626a263#diff-bf79b7ea0085308139af6de0afad9a9f22f13d4563cc56d784994414d88c5dd1
+        if ActiveSupport::VERSION::MAJOR >= 7
+          def callback_filter(callback)
+            callback.filter
+          end
+        else
+          def callback_filter(callback)
+            callback.raw_filter
           end
         end
       end


### PR DESCRIPTION
This PR adds rails 7.0 to the matrix test and fixed a compatibility error.

I've confirmed that jruby fails for all ruby versions.
It is for bson incompatibility for jruby 9.3+: https://github.com/mongodb/bson-ruby/pull/252