### PR TITLE
Update MongoMapper::Connection.handle_passenger_forking for Mongo 2.x

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -81,7 +81,7 @@ module MongoMapper
       # :nocov:
       if defined?(PhusionPassenger)
         PhusionPassenger.on_event(:starting_worker_process) do |forked|
-          connection.connect if forked
+          connection.reconnect if forked
         end
       end
       # :nocov:

--- a/spec/unit/mongo_mapper_spec.rb
+++ b/spec/unit/mongo_mapper_spec.rb
@@ -133,5 +133,10 @@ describe "MongoMapper" do
       MongoMapper.should_receive(:handle_passenger_forking).once
       MongoMapper.setup(config, 'development', :logger => logger)
     end
+
+    it "should use the right reconnect method" do
+      Mongo::Client.instance_methods.should_not include(:connect) # v1
+      Mongo::Client.instance_methods.should include(:reconnect) # v1
+    end
   end
 end


### PR DESCRIPTION
The Mongo Ruby driver 2.x series no longer includes the connect() method.
Use reconnect(), which was originally aliased to connect() in the 1.x driver.