### PR TITLE
Using hooks with options fail in Ruby 3.0

### DIFF
--- a/lib/mongo_mapper/plugins/embedded_callbacks.rb
+++ b/lib/mongo_mapper/plugins/embedded_callbacks.rb
@@ -49,9 +49,9 @@ module MongoMapper
                 class << self
                   alias_method :__original_#{callback}, :#{callback}
 
-                  def #{callback}(*args, &block)
+                  def #{callback}(*args, **options, &block)
                     embedded_callbacks_on if @embedded_callbacks_status.nil?
-                    __original_#{callback}(*args, &block)
+                    __original_#{callback}(*args, **options, &block)
                   end
                 end
               CALLBACK


### PR DESCRIPTION
In Ruby 3.0, positional and keyword arguments are separated.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

In this code, if `**options` is missing, passed options is a part of `*args`.

Here is one of `__original_#{callback}`.

https://github.com/rails/rails/blob/v6.1.6/activemodel/lib/active_model/callbacks.rb#L130-L133

This method receives `*args` and `**options`.
Before Ruby 2.7, the last Hash of `*args` will be `**options`.
After Ruby 3.0, `*args` is still `*args`.  `**options` will be empty.

---

I couldn't find a test for this code.
Adding tests to this change will take time.  So I made a PR without test.  Sorry :pray:
If tests are mandatory to merge, any advice would be appreciated.