### PR TITLE
Hide Coveralls badge from README temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Ruby Object Mapper for Mongo.
 
 [<img src="https://github.com/mongomapper/mongomapper/workflows/Ruby/badge.svg?branch=master" alt="Build Status" />](https://github.com/mongomapper/mongomapper/actions?query=workflow%3ARuby+branch%3Amaster)
 
-[<img src="https://coveralls.io/repos/mongomapper/mongomapper/badge.svg" alt="Coverage Status" />](https://coveralls.io/r/mongomapper/mongomapper)
+<!-- [<img src="https://coveralls.io/repos/mongomapper/mongomapper/badge.svg" alt="Coverage Status" />](https://coveralls.io/r/mongomapper/mongomapper) -->
 
 ## Install
 


### PR DESCRIPTION
Coveralls doesn't show the correct coverage for now.
So let's hide its badge temporarily.

ref: https://github.com/mongomapper/mongomapper/issues/702