### PR TITLE
Fix Time#to_s(:number) deprecation warning for Rails 7.0

### DIFF
--- a/lib/mongo_mapper/plugins/caching.rb
+++ b/lib/mongo_mapper/plugins/caching.rb
@@ -9,7 +9,7 @@ module MongoMapper
                       when !persisted?
                         "#{self.class.name}/new"
                       when timestamp = self[:updated_at]
-                        "#{self.class.name}/#{id}-#{timestamp.to_s(:number)}"
+                        "#{self.class.name}/#{id}-#{timestamp.to_formatted_s(:number)}"
                       else
                         "#{self.class.name}/#{id}"
                     end


### PR DESCRIPTION
This pull request replaces `Time#to_s(:number)` with `Time#to_formatted_s(:number)`. It fixes #700.

`Time#to_formatted_s` is compatible through recent Rails versions.

- Rails 6.1
  https://github.com/rails/rails/blob/6-1-stable/activesupport/lib/active_support/core_ext/time/conversions.rb#L53-L59
- Rails 7.0
  https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/core_ext/time/conversions.rb#L53-L61

There are no deprecation warnings on `Time#to_s(:number)`:

- Ruby 3.0 / Rails 7.0
  https://github.com/mongomapper/mongomapper/runs/6815412123?check_suite_focus=true#step:6:10
- Ruby 3.1 / Rails 7.0
  https://github.com/mongomapper/mongomapper/runs/6815412506?check_suite_focus=true#step:6:10