### PR TITLE
Update README about supported versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -92,7 +92,6 @@ jobs:
         ports:
           - 27017:27017
     env:
-      JRUBY_OPTS: "--1.9"
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
       ENABLE_SHARDING: "${{ matrix.enable-sharding }}"
     steps:

--- a/README.md
+++ b/README.md
@@ -30,15 +30,16 @@ work some more on the project, send an email to Scott Taylor
 
 MongoMapper is tested against:
 
-* MRI 2.4 - 3.0.1
-* JRuby (Versions with 1.9 compatibility)
+* MRI 2.4 - 3.1
+* JRuby (Versions with 2.6 compatibility)
 
 Additionally, MongoMapper is tested against:
 
 * Rails 5.0 - 5.2
 * Rails 6.0 - 6.1
+* Rails 7.0
 
-Note, if you are using Ruby 3.0+, you'll need Rails 6.
+Note, if you are using Ruby 3.0+, you'll need Rails 6.0+.
 
 ## Contributing & Development
 


### PR DESCRIPTION
This PR updates supported versions described in README.

Note that the CI tests against JRuby 9.3 which is compatible Ruby 2.6 now.
https://www.jruby.org/2022/03/23/jruby-9-3-4-0.html
