### PR TITLE
Add `MongoMapper.filter_attributes`

### DIFF
--- a/lib/mongo_mapper.rb
+++ b/lib/mongo_mapper.rb
@@ -25,6 +25,7 @@ module MongoMapper
   autoload :Translation,            'mongo_mapper/translation'
   autoload :Version,                'mongo_mapper/version'
   autoload :Utils,                  'mongo_mapper/utils'
+  autoload :Options,                'mongo_mapper/options'
 
   module Middleware
     autoload :IdentityMap, 'mongo_mapper/middleware/identity_map'
@@ -96,6 +97,7 @@ module MongoMapper
   end
 
   extend Connection
+  extend Options
 end
 
 Dir[File.join(File.dirname(__FILE__), 'mongo_mapper', 'extensions', '*.rb')].each do |extension|

--- a/lib/mongo_mapper/options.rb
+++ b/lib/mongo_mapper/options.rb
@@ -1,11 +1,13 @@
-module Options
-  # @api public
-  def filter_attributes=(attributes)
-    @filter_attributes = attributes
-  end
+module MongoMapper
+  module Options
+    # @api public
+    def filter_attributes=(attributes)
+      @filter_attributes = attributes
+    end
 
-  # @api public
-  def filter_attributes
-    @filter_attributes || []
+    # @api public
+    def filter_attributes
+      @filter_attributes || []
+    end
   end
 end

--- a/lib/mongo_mapper/options.rb
+++ b/lib/mongo_mapper/options.rb
@@ -1,0 +1,11 @@
+module Options
+  # @api public
+  def filter_attributes=(attributes)
+    @filter_attributes = attributes
+  end
+
+  # @api public
+  def filter_attributes
+    @filter_attributes || []
+  end
+end

--- a/lib/mongo_mapper/plugins/inspect.rb
+++ b/lib/mongo_mapper/plugins/inspect.rb
@@ -7,7 +7,9 @@ module MongoMapper
       def inspect(include_nil = false)
         keys = include_nil ? key_names : attributes.keys
         attributes_as_nice_string = keys.sort.collect do |name|
-          "#{name}: #{self.send(:"#{name}").inspect}"
+          raw_value = self.send(:"#{name}").inspect
+          filtered_value = MongoMapper::Utils.filter.filter_param(name, raw_value)
+          "#{name}: #{filtered_value}"
         end.join(", ")
         "#<#{self.class} #{attributes_as_nice_string}>"
       end

--- a/lib/mongo_mapper/railtie.rb
+++ b/lib/mongo_mapper/railtie.rb
@@ -41,6 +41,12 @@ module MongoMapper
       end
     end
 
+    initializer "mongo_mapper.filter_attributes=" do |app|
+      ActiveSupport.on_load(:mongo_mapper) do
+        MongoMapper.filter_attributes += app.config.filter_parameters
+      end
+    end
+
     # This sets the database configuration and establishes the connection.
     initializer "mongo_mapper.initialize_database" do |app|
       config_file = Rails.root.join('config/mongo.yml')

--- a/lib/mongo_mapper/utils.rb
+++ b/lib/mongo_mapper/utils.rb
@@ -1,3 +1,5 @@
+require "active_support/parameter_filter"
+
 module MongoMapper
   module Utils
     def self.get_safe_options(options)
@@ -7,6 +9,10 @@ module MongoMapper
       safe = {:w => 0} if safe == false
       safe = {:w => safe} if safe.is_a? Integer
       safe
+    end
+
+    def self.filter
+      @filter ||= ActiveSupport::ParameterFilter.new(MongoMapper.filter_attributes)
     end
   end
 end

--- a/spec/unit/inspect_spec.rb
+++ b/spec/unit/inspect_spec.rb
@@ -44,4 +44,46 @@ describe "Inspect" do
       doc.inspect.should =~ /_id:.*, pet: .*_id.*, name: "Kitten".*/
     end
   end
+
+  context "#inspect with filter_attributes" do
+    before do
+      MongoMapper::Utils.remove_instance_variable(:@filter) if MongoMapper::Utils.instance_variable_defined?(:@filter)
+      MongoMapper.filter_attributes = [:email, :card_number, :phone_number]
+    end
+
+    after do
+      MongoMapper.filter_attributes =[]
+      MongoMapper::Utils.remove_instance_variable(:@filter) if MongoMapper::Utils.instance_variable_defined?(:@filter)
+    end
+
+    it "should filter the fields given by filter_attributes" do
+      document = Doc('User') do
+        key :name,  String
+        key :age,   Integer
+        key :email, String
+        key :card_number, String
+      end
+      doc = document.new(
+        :name => 'John',
+        :age => 29,
+        :email => 'mongomapper@example.com',
+        :card_number => '123'
+      )
+
+      doc.inspect.should =~ /_id:.*, age: 29, card_number: \[FILTERED\], email: \[FILTERED\], name: "John"/
+    end
+
+    it "should filter the fields given by filter_attributes for embedded document" do
+      document = EDoc('Profile') do
+        key :job,  String
+        key :phone_number,  String
+      end
+      doc = document.new(
+        :job => 'Software Engineer',
+        :phone_number => '09011110000'
+      )
+
+      doc.inspect.should =~ /job: "Software Engineer", phone_number: \[FILTERED\]/
+    end
+  end
 end

--- a/spec/unit/mongo_mapper_spec.rb
+++ b/spec/unit/mongo_mapper_spec.rb
@@ -139,4 +139,13 @@ describe "MongoMapper" do
       Mongo::Client.instance_methods.should include(:reconnect) # v1
     end
   end
+
+  context "options" do
+    it "should sets/returns filtered_attributes correctly" do
+      MongoMapper.filter_attributes.should == []
+      filtered_attributes = [:password, :credit_number]
+      MongoMapper.filter_attributes = filtered_attributes
+      MongoMapper.filter_attributes.should == filtered_attributes
+    end
+  end
 end


### PR DESCRIPTION
## Background

The ActiveRecord has `filter_attributes` option in order to conceal private information such as user email address.
See also https://github.com/rails/rails/pull/33756
So we would like to do the same thing on the mongomapper.

## What we did

We added `filter_attributes` option and made `#inspect` filter the value based on the given keywords.