### PR TITLE
Fix default value with descendant of embedded document

### DIFF
--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -110,7 +110,7 @@ module MongoMapper
         end
 
         def from_mongo(value)
-          value && (value.instance_of?(self) ? value : load(value))
+          value && (value.is_a?(self) ? value : load(value))
         end
 
         # load is overridden in identity map to ensure same objects are loaded

--- a/spec/functional/keys_spec.rb
+++ b/spec/functional/keys_spec.rb
@@ -369,18 +369,15 @@ describe "Keys" do
   end
 
   describe "default value is child of embedded class" do
-    class EmbeddedParent
-      include MongoMapper::EmbeddedDocument
-    end
-    class EmbeddedChild < EmbeddedParent
-    end
-    class DocumentWithEmbeddedAndDefaultValue
-      include MongoMapper::Document
-      key :my_embedded, EmbeddedParent, default: -> { EmbeddedChild.new }
-    end
     it "should work" do
-      instance = DocumentWithEmbeddedAndDefaultValue.new
-      instance.my_embedded.should be_instance_of(EmbeddedChild)
+      embedded_class = EDoc("Embedded")
+      embedded_subclass = Subclass(embedded_class, embedded_class)
+      doc_class = Doc("Doc") do
+        key :my_embedded, embedded_class, default: -> { embedded_subclass.new }
+      end
+
+      doc = doc_class.new
+      doc.my_embedded.should be_instance_of(embedded_subclass)
     end
   end
 end

--- a/spec/functional/keys_spec.rb
+++ b/spec/functional/keys_spec.rb
@@ -367,4 +367,20 @@ describe "Keys" do
       instance.a_num.should == 10
     end
   end
+
+  describe "default value is child of embedded class" do
+    class EmbeddedParent
+      include MongoMapper::EmbeddedDocument
+    end
+    class EmbeddedChild < EmbeddedParent
+    end
+    class DocumentWithEmbeddedAndDefaultValue
+      include MongoMapper::Document
+      key :my_embedded, EmbeddedParent, default: -> { EmbeddedChild.new }
+    end
+    it "should work" do
+      instance = DocumentWithEmbeddedAndDefaultValue.new
+      instance.my_embedded.instance_of?(EmbeddedChild)
+    end
+  end
 end

--- a/spec/functional/keys_spec.rb
+++ b/spec/functional/keys_spec.rb
@@ -380,7 +380,7 @@ describe "Keys" do
     end
     it "should work" do
       instance = DocumentWithEmbeddedAndDefaultValue.new
-      instance.my_embedded.instance_of?(EmbeddedChild)
+      instance.my_embedded.should be_instance_of(EmbeddedChild)
     end
   end
 end


### PR DESCRIPTION
Fix #708

## Problem

Given the following situation, `A.new` causes a NoMethodError while calling `B.from_mongo` with the return value of `Key#default_value`.

```ruby
class B
  include MongoMapper:EmbeddedDocument
end

class C < B
end

class A
  include MongoMapper::Document

  field :bar, B, default_value: ->{ C.new } # default value is the type's descendant
end

A.new
```

```
/vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:479:in `block in initialize_default_values': undefined method `key?' for #<C _id: BSON::ObjectId('62b92fa3ffa5c3b60922cf97'), _type: "C"> (NoMethodError)
Did you mean?  keys
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:478:in `each'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:478:in `initialize_default_values'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:287:in `initialize_from_database'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:123:in `load'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:113:in `from_mongo'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys/key.rb:64:in `get'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:460:in `internal_write_key'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:480:in `block in initialize_default_values'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:478:in `each'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:478:in `initialize_default_values'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/keys.rb:279:in `initialize'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/sci.rb:77:in `initialize'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/callbacks.rb:8:in `block in initialize'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activesupport-7.0.3/lib/active_support/callbacks.rb:99:in `run_callbacks'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/embedded_callbacks.rb:78:in `run_callbacks'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/callbacks.rb:8:in `initialize'
	from /vendor/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/mongo_mapper-0.15.6/lib/mongo_mapper/plugins/partial_updates.rb:18:in `initialize'
	from ./mongomapper-inheritance.rb:24:in `new'
	from ./mongomapper-inheritance.rb:24:in `<main>'
```

It is becasuse `B.from_mongo` expects an instance of `B` or an attributes hash, but `Key#default_value` returns an instance of `C`. It's a conflict.

## Solution

`B.from_mongo` had also accepted descendants of `B` with `is_a?` with 0.12.0 and prior. It has been replaced with `instance_of?` for performance improvements.
https://github.com/mongomapper/mongomapper/commit/a60b04cc360f200b9f3c773150a53928192b2c8e#diff-f31cdda1ba47c5a9f26f34182b7dede3826f31e4652736e848dff0acc3019c46L57-R57

However, I found that `instance_of?` is a bit more performant than `is_a?`, but I thinks we can ignore it compared to querying to a database.

So let's revert it to work around the issue.

### Benchmark

```ruby
require "benchmark"

class A; end
class B < A; end
class C; end

Benchmark.bm(12) do |x|
  x.report("is_a?")        { 1000.times { B.is_a?(A) };        1000.times { C.is_a?(A) }; }
  x.report("instance_of?") { 1000.times { B.instance_of?(A) }; 1000.times { C.instance_of?(A) }; }
end
```

```
$ ruby ~/Desktop/benchmark.rb
                   user     system      total        real
is_a?          0.000094   0.000001   0.000095 (  0.000094)
instance_of?   0.000083   0.000001   0.000084 (  0.000083)
```

## Other solution?

We can convert the input value to `B.from_mongo` to an attributes hash with `B.to_mongo` to conform its expectation.
I'm not sure, but I think it is most prefereable to update `Key#get` like the following diff:

```diff
--- a/lib/mongo_mapper/plugins/keys/key.rb
+++ b/lib/mongo_mapper/plugins/keys/key.rb
@@ -61,7 +61,7 @@ module MongoMapper
           # Special Case: Generate default _id on access
           value = default_value if @is_id and !value
 
-          value = type ? type.from_mongo(value) : value
+          value = type ? type.from_mongo(type.to_moongo(value)) : value
 
           if @typecast
             klass = typecast_class # Don't make this lookup on every call
```

We have other options to update: `B.from_mongo`, `B.load`, and `Key#default_value`.
But it can change their behaviors, return values, or expected roles.

 