### PR TITLE
Fix default value with custom objects implementing to_mongo and from_mongo

### DIFF
--- a/lib/mongo_mapper/plugins/keys/key.rb
+++ b/lib/mongo_mapper/plugins/keys/key.rb
@@ -90,11 +90,11 @@ module MongoMapper
           return unless default?
 
           if default.instance_of? Proc
-            default.call
+            type ? type.to_mongo(default.call) : default.call
           else
             # Using Marshal is easiest way to get a copy of mutable objects
             # without getting an error on immutable objects
-            Marshal.load(Marshal.dump(default))
+            type ? type.to_mongo(Marshal.load(Marshal.dump(default))) : Marshal.load(Marshal.dump(default))
           end
         end
 

--- a/spec/functional/keys_spec.rb
+++ b/spec/functional/keys_spec.rb
@@ -367,4 +367,80 @@ describe "Keys" do
       instance.a_num.should == 10
     end
   end
+
+  describe 'default value is child of embedded class' do
+    class EmbeddedParent
+      include MongoMapper::EmbeddedDocument
+    end
+    class EmbeddedChild < EmbeddedParent
+    end
+
+    context 'with type' do
+      class DocumentWithEmbeddedAndDefaultValue
+        include MongoMapper::Document
+        key :my_embedded, EmbeddedParent, default: -> { EmbeddedChild.new }
+      end
+
+      it "should work" do
+        instance = DocumentWithEmbeddedAndDefaultValue.new
+        instance.my_embedded.should be_instance_of(EmbeddedChild)
+      end
+    end
+
+    context 'without type' do
+      class DocumentWithEmbeddedAndDefaultValueWithoutType
+        include MongoMapper::Document
+        key :my_embedded, EmbeddedParent, default: -> { EmbeddedChild.new }
+      end
+
+      it "should work" do
+        instance = DocumentWithEmbeddedAndDefaultValueWithoutType.new
+        instance.my_embedded.should be_instance_of(EmbeddedChild)
+      end
+    end
+  end
+
+  describe 'default value is a custom class' do
+    class TimeOfDay
+      attr_reader :seconds
+
+      def initialize(seconds)
+        @seconds = seconds
+      end
+
+      def self.from_mongo(value)
+        return nil if value.blank?
+
+        new(value.to_i)
+      end
+
+      def self.to_mongo(value)
+        return nil if value.blank?
+
+        value.seconds
+      end
+    end
+
+    context 'with type' do
+      class DocumentWithCustomClass
+        include MongoMapper::Document
+        key :my_embedded, TimeOfDay, default: -> { TimeOfDay.new(900) }
+      end
+      it "should work" do
+        instance = DocumentWithCustomClass.new
+        instance.my_embedded.should be_instance_of(TimeOfDay)
+      end
+    end
+
+    context 'without type' do
+      class DocumentWithCustomClassWithoutType
+        include MongoMapper::Document
+        key :my_embedded, default: -> { TimeOfDay.new(900) }
+      end
+      it "should work" do
+        instance = DocumentWithCustomClass.new
+        instance.my_embedded.should be_instance_of(TimeOfDay)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes https://github.com/mongomapper/mongomapper/issues/708

7685eda stopped calling to_mongo on default values to fix an issue when no type was specified. This broke embedded documents with inheritance and custom objects when type was specified.