### PR TITLE
Keep type of default_value of embedded documents as declared

### DIFF
--- a/lib/mongo_mapper/plugins/keys.rb
+++ b/lib/mongo_mapper/plugins/keys.rb
@@ -477,7 +477,9 @@ module MongoMapper
       def initialize_default_values(except = {})
         @__mm_default_keys.each do |key|
           if !(except && except.key?(key.name))
-            internal_write_key key.name, key.default_value, false
+            value = key.default_value
+            value = key.type ? key.type.to_mongo(value) : value
+            internal_write_key key.name, value, false
           end
         end
       end

--- a/lib/mongo_mapper/plugins/keys/key.rb
+++ b/lib/mongo_mapper/plugins/keys/key.rb
@@ -90,11 +90,11 @@ module MongoMapper
           return unless default?
 
           if default.instance_of? Proc
-            type ? type.to_mongo(default.call) : default.call
+            default.call
           else
             # Using Marshal is easiest way to get a copy of mutable objects
             # without getting an error on immutable objects
-            type ? type.to_mongo(Marshal.load(Marshal.dump(default))) : Marshal.load(Marshal.dump(default))
+            Marshal.load(Marshal.dump(default))
           end
         end
 

--- a/spec/unit/key_spec.rb
+++ b/spec/unit/key_spec.rb
@@ -276,6 +276,17 @@ describe "Key" do
       it "should work with procs" do
          Key.new(:foo, String, :default => lambda { return 'hello world' }).default_value.should == "hello world"
       end
+
+      it "should work with embedded document" do
+        embedded = EDoc()
+        Key.new(:foo, embedded, :default => lambda { embedded.new }).default_value.should be_instance_of(embedded)
+      end
+
+      it "should work with subclass of embedded document" do
+        embedded = EDoc()
+        subclass = Subclass(embedded)
+        Key.new(:foo, embedded, :default => lambda { subclass.new }).default_value.should be_instance_of(subclass)
+      end
     end
   end
 end # KeyTest


### PR DESCRIPTION
Follows up: #708, #713

#713 changed the type of a return value from `Key#default_value` for an embedded
document from an instance of the embedded document to an attributes hash like
the following:

```ruby
class Foo
  include MongoMapper::EmbeddedDocument
end

Key.new(:foo, Foo, default: ->{ Foo.new }).default_value

# Before #713
#=> an instance of Foo

# After #713
#=> {"_id" => BSON::ObjectId('....'), "_type" => "Foo" }
```

This commit fixes it by calling `to_mongo` from outside of `Key#default_value`.