### PR TITLE
Exclude JRuby with rails 5.0, 5.1, 5.2 from CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,6 +33,18 @@ jobs:
           - "0"
         exclude:
           - ruby-version: jruby
+            gemfile: gemfiles/rails5_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: jruby
+            gemfile: gemfiles/rails5_1.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: jruby
+            gemfile: gemfiles/rails5_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: jruby
             gemfile: gemfiles/rails7_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"


### PR DESCRIPTION
JRuby 9.4 is compatible with Ruby 3.1 and it does not support old keyword argument notation.
https://github.com/jruby/jruby/releases/tag/9.4.0.0


https://github.com/mongomapper/mongomapper/actions/runs/3937244306/jobs/6734548022
```
  39) Validations Validations on a Document validating confirmation of should work with validates_confirmation_of macro
      Failure/Error: run_callbacks(:validation) { super }

      ArgumentError:
        wrong number of arguments (given 2, expected 0..1)
      # ./lib/mongo_mapper/plugins/validations.rb:89:in `block in run_validations!'
      # ./lib/mongo_mapper/plugins/embedded_callbacks.rb:78:in `run_callbacks'
      # ./lib/mongo_mapper/plugins/validations.rb:89:in `run_validations!'
      # ./lib/mongo_mapper/plugins/validations.rb:27:in `valid?'
      # ./spec/support/matchers.rb:6:in `block in matches?'
      # ./spec/unit/validations_spec.rb:30:in `block in <main>'
```