### PR TITLE
Update Ruby patch versions for CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,10 +17,10 @@ jobs:
           - 2.4.10
           - 2.5.9
           - 2.6.10
-          - 2.7.6
-          - 3.0.4
-          - 3.1.2
-          - 3.2.0
+          - 2.7.8
+          - 3.0.6
+          - 3.1.4
+          - 3.2.2
         gemfile:
           - gemfiles/rails5_0.gemfile
           - gemfiles/rails5_1.gemfile
@@ -69,48 +69,48 @@ jobs:
             gemfile: gemfiles/rails7_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.0.4
+          - ruby-version: 3.0.6
             gemfile: gemfiles/rails5_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.0.4
+          - ruby-version: 3.0.6
             gemfile: gemfiles/rails5_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.0.4
+          - ruby-version: 3.0.6
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.1.2
+          - ruby-version: 3.1.4
             gemfile: gemfiles/rails5_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.1.2
+          - ruby-version: 3.1.4
             gemfile: gemfiles/rails5_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.1.2
+          - ruby-version: 3.1.4
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.2.0
+          - ruby-version: 3.2.2
             gemfile: gemfiles/rails5_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.2.0
+          - ruby-version: 3.2.2
             gemfile: gemfiles/rails5_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.2.0
+          - ruby-version: 3.2.2
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
         include:
-          - { "ruby-version": 3.1.2, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
-          - { "ruby-version": 3.1.2, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.1.2, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
-          - { "ruby-version": 3.1.2, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
-          - { "ruby-version": 3.1.2, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.1.4, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
+          - { "ruby-version": 3.1.4, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.1.4, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
+          - { "ruby-version": 3.1.4, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
+          - { "ruby-version": 3.1.4, "gemfile": "gemfiles/rails7_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}


### PR DESCRIPTION
Note: This pull request also runs CI with the latest Rails which are released in these days.
https://rubyonrails.org/2023/8/22/Rails-Versions-7-0-7-2-6-1-7-6-have-been-released