### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,6 +21,7 @@ jobs:
           - 3.0.6
           - 3.1.4
           - 3.2.2
+          - 3.3.0
         gemfile:
           - gemfiles/rails5_0.gemfile
           - gemfiles/rails5_1.gemfile
@@ -137,16 +138,30 @@ jobs:
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+
+          # ruby 3.3 doesn't work with rails <= 5.2
+          - ruby-version: 3.3.0
+            gemfile: gemfiles/rails5_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: 3.3.0
+            gemfile: gemfiles/rails5_1.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: 3.3.0
+            gemfile: gemfiles/rails5_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
         include:
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.2.2, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
       mongo (~> 2.0)
     power_assert (2.0.1)
     racc (1.6.0)
-    rack (2.2.3.1)
+    rack (2.2.8)
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
     rails (6.1.6)


### PR DESCRIPTION
I added Ruby 3.3.0 to the CI matrix. There's no need to update the implementation to support Ruby 3.3.0.