### PR TITLE
Support scale option for collStats

### DIFF
--- a/lib/mongo_mapper/plugins/stats.rb
+++ b/lib/mongo_mapper/plugins/stats.rb
@@ -5,16 +5,9 @@ module MongoMapper
     module Stats
       extend ActiveSupport::Concern
       module ClassMethods
-        ALLOWED_OPTIONS = [:scale].freeze
-
-        def stats(opts={})
+        def stats(scale: nil)
           query = { :collstats => collection.name }
-
-          opts.each do |k, v|
-            if ALLOWED_OPTIONS.include?(k.to_sym)
-              query[k.to_sym] = v
-            end
-          end
+          query[:scale] = scale if scale
 
           stats = database.command(query).documents[0]
           Struct.new(*stats.keys.collect { |key| key.underscore.to_sym }).new(*stats.values)

--- a/lib/mongo_mapper/plugins/stats.rb
+++ b/lib/mongo_mapper/plugins/stats.rb
@@ -5,8 +5,18 @@ module MongoMapper
     module Stats
       extend ActiveSupport::Concern
       module ClassMethods
-        def stats
-          stats = database.command(:collstats => collection.name).documents[0]
+        ALLOWED_OPTIONS = [:scale].freeze
+
+        def stats(opts={})
+          query = { :collstats => collection.name }
+
+          opts.each do |k, v|
+            if ALLOWED_OPTIONS.include?(k.to_sym)
+              query[k.to_sym] = v
+            end
+          end
+
+          stats = database.command(query).documents[0]
           Struct.new(*stats.keys.collect { |key| key.underscore.to_sym }).new(*stats.values)
         rescue
           nil

--- a/spec/functional/stats_spec.rb
+++ b/spec/functional/stats_spec.rb
@@ -83,17 +83,9 @@ describe "Stats" do
       Docs.stats.total_index_size.should == get_stats['totalIndexSize']
     end
 
-    context 'with option' do
-      context 'option[:scale]' do
-        it "should have the correct total index size (with scale)" do
-          Docs.stats({ scale: 1_024 }).total_index_size.should == (get_stats['totalIndexSize'] / 1_024)
-        end
-      end
-
-      context 'not allowed option' do
-        it "should have the correct total index size (ignores invalid option)" do
-          Docs.stats({ invalid: 1 }).total_index_size.should == get_stats['totalIndexSize']
-        end
+    context 'with scale keyword argument' do
+      it "should have the correct total index size (with scale)" do
+        Docs.stats(scale: 1_024).total_index_size.should == (get_stats['totalIndexSize'] / 1_024)
       end
     end
   end

--- a/spec/functional/stats_spec.rb
+++ b/spec/functional/stats_spec.rb
@@ -82,5 +82,19 @@ describe "Stats" do
     it "should have the correct total index size" do
       Docs.stats.total_index_size.should == get_stats['totalIndexSize']
     end
+
+    context 'with option' do
+      context 'option[:scale]' do
+        it "should have the correct total index size (with scale)" do
+          Docs.stats({ scale: 1_024 }).total_index_size.should == (get_stats['totalIndexSize'] / 1_024)
+        end
+      end
+
+      context 'not allowed option' do
+        it "should have the correct total index size (ignores invalid option)" do
+          Docs.stats({ invalid: 1 }).total_index_size.should == get_stats['totalIndexSize']
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Background

- I sometimes uses `scale` option with dbstats/collstats in mongosh.
  - ref: https://www.mongodb.com/docs/manual/reference/command/collStats/#syntax
- MongoMapper also supports stats(collstats) but does not support scale option.

## What I did

- I just made MongoMapper supports scale option for stats(collstats).