### PR TITLE
Add Rails 7.2 to CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,6 +30,7 @@ jobs:
           - gemfiles/rails6_1.gemfile
           - gemfiles/rails7_0.gemfile
           - gemfiles/rails7_1.gemfile
+          - gemfiles/rails7_2.gemfile
         mongo-image:
           - mongo:4.4
         enable-sharding:
@@ -58,6 +59,10 @@ jobs:
             gemfile: gemfiles/rails7_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+          - ruby-version: jruby
+            gemfile: gemfiles/rails7_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
 
           # ruby 2.4 doesn't work with rails >= 6.0
           - ruby-version: 2.4.10
@@ -76,6 +81,10 @@ jobs:
             gemfile: gemfiles/rails7_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+          - ruby-version: 2.4.10
+            gemfile: gemfiles/rails7_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
 
           # ruby 2.5 doesn't work with rails >= 7.0
           - ruby-version: 2.5.9
@@ -86,6 +95,10 @@ jobs:
             gemfile: gemfiles/rails7_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+          - ruby-version: 2.5.9
+            gemfile: gemfiles/rails7_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
 
           # ruby 2.6 doesn't work with rails >= 7.0
           - ruby-version: 2.6.10
@@ -94,6 +107,22 @@ jobs:
             enable-sharding: "0"
           - ruby-version: 2.6.10
             gemfile: gemfiles/rails7_1.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: 2.6.10
+            gemfile: gemfiles/rails7_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+
+          # ruby 2.7 doesn't work with rails >= 7.2
+          - ruby-version: 2.7.8
+            gemfile: gemfiles/rails7_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+
+          # ruby 3.0 doesn't work with rails >= 7.2
+          - ruby-version: 3.0.6
+            gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
@@ -153,15 +182,15 @@ jobs:
             mongo-image: mongo:4.4
             enable-sharding: "0"
         include:
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_1.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - PR-721 Masato Ikeda <masato.ikeda@gmail.com> Add Ruby 3.3 to CI matrix
 - PR-722 mitsubosh <yuya.mitsuboshi@gmail.com> Support scale option for collStats
+- PR-728 Masato Ikeda <masato.ikeda@gmail.com> Add Rails 7.2 to CI matrix
 
 ### Bug Fixes:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Additionally, MongoMapper is tested against:
 
 - Rails 5.0 - 5.2
 - Rails 6.0 - 6.1
-- Rails 7.0 - 7.1
+- Rails 7.0 - 7.2
 
 Note, if you are using Ruby 3.0+, you'll need Rails 6.0+.
 

--- a/gemfiles/rails7_2.gemfile
+++ b/gemfiles/rails7_2.gemfile
@@ -1,0 +1,4 @@
+eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+gemspec :path => '../'
+
+gem 'rails', '~> 7.2.0', group: :test


### PR DESCRIPTION
This PR adds Rails 7.2 to CI matrix.

I confirmed that there are no implementation changes or deprecation warnings in CI against Rails 7.2 👍 