### PR TITLE
Update actions/checkout from v2 to v4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -201,7 +201,7 @@ jobs:
       ENABLE_SHARDING: "${{ matrix.enable-sharding }}"
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This PR will fix the following deprecation warning shown in [the previous CI summary](https://github.com/mongomapper/mongomapper/actions/runs/11081126729):

<img width="1166" alt="image" src="https://github.com/user-attachments/assets/9d947224-1fef-40f6-a021-e2527c01e744">
