### PR TITLE
Support Rails 8.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,6 +31,7 @@ jobs:
           - gemfiles/rails7_0.gemfile
           - gemfiles/rails7_1.gemfile
           - gemfiles/rails7_2.gemfile
+          - gemfiles/rails8_0.gemfile
         mongo-image:
           - mongo:4.4
         enable-sharding:
@@ -63,6 +64,10 @@ jobs:
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+          - ruby-version: jruby
+            gemfile: gemfiles/rails8_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
 
           # ruby 2.4 doesn't work with rails >= 6.0
           - ruby-version: 2.4.10
@@ -85,6 +90,10 @@ jobs:
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+          - ruby-version: 2.4.10
+            gemfile: gemfiles/rails8_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
 
           # ruby 2.5 doesn't work with rails >= 7.0
           - ruby-version: 2.5.9
@@ -97,6 +106,10 @@ jobs:
             enable-sharding: "0"
           - ruby-version: 2.5.9
             gemfile: gemfiles/rails7_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: 2.5.9
+            gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
@@ -113,16 +126,28 @@ jobs:
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+          - ruby-version: 2.6.10
+            gemfile: gemfiles/rails8_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
 
           # ruby 2.7 doesn't work with rails >= 7.2
           - ruby-version: 2.7.8
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+          - ruby-version: 2.7.8
+            gemfile: gemfiles/rails8_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
 
           # ruby 3.0 doesn't work with rails >= 7.2
           - ruby-version: 3.0.6
             gemfile: gemfiles/rails7_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: 3.0.6
+            gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
@@ -154,6 +179,12 @@ jobs:
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
+          # ruby 3.1 doesn't work with rails >= 8.0
+          - ruby-version: 3.1.4
+            gemfile: gemfiles/rails8_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+
           # ruby 3.2 doesn't work with rails <= 5.2
           - ruby-version: 3.2.2
             gemfile: gemfiles/rails5_0.gemfile
@@ -182,15 +213,15 @@ jobs:
             mongo-image: mongo:4.4
             enable-sharding: "0"
         include:
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails7_2.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Additionally, MongoMapper is tested against:
 - Rails 5.0 - 5.2
 - Rails 6.0 - 6.1
 - Rails 7.0 - 7.2
+- Rails 8.0
 
 Note, if you are using Ruby 3.0+, you'll need Rails 6.0+.
 

--- a/gemfiles/rails8_0.gemfile
+++ b/gemfiles/rails8_0.gemfile
@@ -1,0 +1,4 @@
+eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+gemspec :path => '../'
+
+gem 'rails', '~> 8.0.0', group: :test

--- a/lib/mongo_mapper/plugins/serialization.rb
+++ b/lib/mongo_mapper/plugins/serialization.rb
@@ -18,7 +18,7 @@ module MongoMapper
       end
 
       def serializable_hash(options = nil)
-        options ||= {}
+        options = options ? options.dup : {}
 
         options[:only]   = Array.wrap(options[:only]).map { |k| k.to_s }
         options[:except] = Array.wrap(options[:except]).map { |k| k.to_s }


### PR DESCRIPTION
Note that Rails 8.0 requires Ruby >= 3.2.0.
https://rubygems.org/gems/rails/versions/8.0.0