### PR TITLE
Omit Ruby patch version in CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         ruby-version:
           - jruby
-          - 2.4.10
-          - 2.5.9
-          - 2.6.10
-          - 2.7.8
-          - 3.0.6
-          - 3.1.4
-          - 3.2.2
-          - 3.3.0
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
+          - 3.3
         gemfile:
           - gemfiles/rails5_0.gemfile
           - gemfiles/rails5_1.gemfile
@@ -70,158 +70,158 @@ jobs:
             enable-sharding: "0"
 
           # ruby 2.4 doesn't work with rails >= 6.0
-          - ruby-version: 2.4.10
+          - ruby-version: 2.4
             gemfile: gemfiles/rails6_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.4.10
+          - ruby-version: 2.4
             gemfile: gemfiles/rails6_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.4.10
+          - ruby-version: 2.4
             gemfile: gemfiles/rails7_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.4.10
+          - ruby-version: 2.4
             gemfile: gemfiles/rails7_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.4.10
+          - ruby-version: 2.4
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.4.10
+          - ruby-version: 2.4
             gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 2.5 doesn't work with rails >= 7.0
-          - ruby-version: 2.5.9
+          - ruby-version: 2.5
             gemfile: gemfiles/rails7_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.5.9
+          - ruby-version: 2.5
             gemfile: gemfiles/rails7_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.5.9
+          - ruby-version: 2.5
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.5.9
+          - ruby-version: 2.5
             gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 2.6 doesn't work with rails >= 7.0
-          - ruby-version: 2.6.10
+          - ruby-version: 2.6
             gemfile: gemfiles/rails7_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.6.10
+          - ruby-version: 2.6
             gemfile: gemfiles/rails7_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.6.10
+          - ruby-version: 2.6
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.6.10
+          - ruby-version: 2.6
             gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 2.7 doesn't work with rails >= 7.2
-          - ruby-version: 2.7.8
+          - ruby-version: 2.7
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 2.7.8
+          - ruby-version: 2.7
             gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 3.0 doesn't work with rails >= 7.2
-          - ruby-version: 3.0.6
+          - ruby-version: 3.0
             gemfile: gemfiles/rails7_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.0.6
+          - ruby-version: 3.0
             gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 3.0 doesn't work with rails <= 5.2
-          - ruby-version: 3.0.6
+          - ruby-version: 3.0
             gemfile: gemfiles/rails5_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.0.6
+          - ruby-version: 3.0
             gemfile: gemfiles/rails5_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.0.6
+          - ruby-version: 3.0
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 3.1 doesn't work with rails <= 5.2
-          - ruby-version: 3.1.4
+          - ruby-version: 3.1
             gemfile: gemfiles/rails5_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.1.4
+          - ruby-version: 3.1
             gemfile: gemfiles/rails5_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.1.4
+          - ruby-version: 3.1
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 3.1 doesn't work with rails >= 8.0
-          - ruby-version: 3.1.4
+          - ruby-version: 3.1
             gemfile: gemfiles/rails8_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 3.2 doesn't work with rails <= 5.2
-          - ruby-version: 3.2.2
+          - ruby-version: 3.2
             gemfile: gemfiles/rails5_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.2.2
+          - ruby-version: 3.2
             gemfile: gemfiles/rails5_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.2.2
+          - ruby-version: 3.2
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
 
           # ruby 3.3 doesn't work with rails <= 5.2
-          - ruby-version: 3.3.0
+          - ruby-version: 3.3
             gemfile: gemfiles/rails5_0.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.3.0
+          - ruby-version: 3.3
             gemfile: gemfiles/rails5_1.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
-          - ruby-version: 3.3.0
+          - ruby-version: 3.3
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
         include:
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.3.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
+          - { "ruby-version": 3.3, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}


### PR DESCRIPTION
ruby/setup-ruby interprets a short version like '2.6' as the latest release corresponding to that version (e.g., 2.6.10).
https://github.com/ruby/setup-ruby?tab=readme-ov-file#supported-version-syntax

Specifying patch versions could lead to omissions and increase the effort required for maintenance. Therefore, let's omit the patch versions.