### PR TITLE
Include MongoMapper version details in MongoDB handshake 

### DIFF
--- a/lib/mongo_mapper/connection.rb
+++ b/lib/mongo_mapper/connection.rb
@@ -50,6 +50,11 @@ module MongoMapper
       config[environment.to_s]
     end
 
+    MONGOMAPPER_WRAPPING_LIBRARY = {
+      name: 'MongoMapper',
+      version: Version,
+    }.freeze
+
     def connect(environment, options={})
       raise 'Set config before connecting. MongoMapper.config = {...}' if config.blank?
       env = config_for_environment(environment).dup
@@ -68,6 +73,8 @@ module MongoMapper
       end
 
       options[:read] = options[:read].to_sym if options[:read].is_a? String
+      options[:wrapping_libraries] = [MONGOMAPPER_WRAPPING_LIBRARY]
+
       MongoMapper.connection = Mongo::Client.new(addresses_or_uri, options)
     end
 


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2025-01-06T19:49:49.811-05:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn8","msg":"client metadata","attr":{"remote":"127.0.0.1:51769","client":"conn8","negotiatedCompressors":[],"doc":{"driver":{`"name":"mongo-ruby-driver|MongoMapper","version":"2.21.0|0.17.0"`},"os":{"type":"darwin","name":"darwin23","architecture":"arm64"},"platform":"Ruby 3.4.1, arm64-darwin23, aarch64-apple-darwin23.6.0, A|"}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.