### PR TITLE
Use eval_gemfile instead of eval

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../gemfiles/Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'gemfiles/Gemfile.common.rb'
 gemspec
 
 gem 'rails', '~> 8.0', group: :test

--- a/gemfiles/rails5_0.gemfile
+++ b/gemfiles/rails5_0.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 5.0.0', :group => :test

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 5.1.0', :group => :test

--- a/gemfiles/rails5_2.gemfile
+++ b/gemfiles/rails5_2.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 5.2.0', :group => :test

--- a/gemfiles/rails6_0.gemfile
+++ b/gemfiles/rails6_0.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 6.0.0', :group => :test

--- a/gemfiles/rails6_1.gemfile
+++ b/gemfiles/rails6_1.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 6.1.0', group: :test

--- a/gemfiles/rails7_0.gemfile
+++ b/gemfiles/rails7_0.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 7.0.0', group: :test

--- a/gemfiles/rails7_1.gemfile
+++ b/gemfiles/rails7_1.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 7.1.0', group: :test

--- a/gemfiles/rails7_2.gemfile
+++ b/gemfiles/rails7_2.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 7.2.0', group: :test

--- a/gemfiles/rails8_0.gemfile
+++ b/gemfiles/rails8_0.gemfile
@@ -1,4 +1,4 @@
-eval File.read(File.expand_path('../Gemfile.common.rb', __FILE__)), nil, 'Gemfile.common.rb'
+eval_gemfile 'Gemfile.common.rb'
 gemspec :path => '../'
 
 gem 'rails', '~> 8.0.0', group: :test


### PR DESCRIPTION
This PR replaces `eval File.read("Gemfile.common.rb")` with `eval_gemfile "Gemfile.common.rb"`.

We need this change to fix dependabot's error: https://github.com/mongomapper/mongomapper/network/updates/1005042077.

As far as I've investigated, dependabot seems to interpret only `eval_gemfile` to load separated gemfiles, not `eval`.
https://github.com/dependabot/dependabot-core/blob/ae1de79b164166f2ae1625282bbe2004f67b9f35/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb#L37-L58
