### PR TITLE
Fix static_keys breaking embedded docs

### DIFF
--- a/lib/mongo_mapper/plugins/keys/static.rb
+++ b/lib/mongo_mapper/plugins/keys/static.rb
@@ -35,7 +35,8 @@ module MongoMapper
         def load_from_database(attrs, with_cast = false)
           return super if !self.class.static_keys || !attrs.respond_to?(:each)
 
-          attrs = attrs.select { |key, _| self.class.key?(key) }
+          embedded_keys = self.class.embedded_associations.map(&:name).map(&:to_s)
+          attrs = attrs.select { |key, _| self.class.key?(key) || key.in?(embedded_keys) }
 
           super(attrs, with_cast)
         end


### PR DESCRIPTION
By checking only against `#keys`, loading from database filters out any embedded documents from a model when `static_keys = true`. This PR fixes that.