### PR TITLE
Add Ruby 4.0 to CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,6 +23,7 @@ jobs:
           - 3.2
           - 3.3
           - 3.4
+          - 4.0
         gemfile:
           - gemfiles/rails5_0.gemfile
           - gemfiles/rails5_1.gemfile
@@ -247,18 +248,32 @@ jobs:
             gemfile: gemfiles/rails5_2.gemfile
             mongo-image: mongo:4.4
             enable-sharding: "0"
+
+          # ruby 4.0 doesn't work with rails <= 5.2
+          - ruby-version: 4.0
+            gemfile: gemfiles/rails5_0.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: 4.0
+            gemfile: gemfiles/rails5_1.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
+          - ruby-version: 4.0
+            gemfile: gemfiles/rails5_2.gemfile
+            mongo-image: mongo:4.4
+            enable-sharding: "0"
         include:
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:8.0",               "enable-sharding": "0" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
-          - { "ruby-version": 3.4, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:8.0", "enable-sharding": "1" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:4.2",               "enable-sharding": "0" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:5.0",               "enable-sharding": "0" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:6.0",               "enable-sharding": "0" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:7.0",               "enable-sharding": "0" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "mongo:8.0",               "enable-sharding": "0" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.2", "enable-sharding": "1" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:4.4", "enable-sharding": "1" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:5.0", "enable-sharding": "1" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:6.0", "enable-sharding": "1" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:7.0", "enable-sharding": "1" }
+          - { "ruby-version": 4.0, "gemfile": "gemfiles/rails8_0.gemfile", "mongo-image": "a2ikm/sharded-mongo:8.0", "enable-sharding": "1" }
     services:
       mongo:
         image: ${{ matrix.mongo-image }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -289,7 +289,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ matrix.ruby-version }}"
-    - name: Install dependencies
-      run: "bundle install --without development"
+        bundler-cache: true
     - name: Run tests
       run: "bundle exec rake"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ work some more on the project, send an email to Scott Taylor
 
 MongoMapper is tested against:
 
-- MRI 2.4 - 3.4
+- MRI 2.4 - 4.0
 - JRuby (Versions with 3.1 compatibility)
 
 Additionally, MongoMapper is tested against:

--- a/gemfiles/rails6_0.gemfile
+++ b/gemfiles/rails6_0.gemfile
@@ -10,3 +10,8 @@ if RUBY_VERSION >= '3.4'
   # activesupport 6.0 depends on the mutex_m gem, which has been extracted as a bundled gem since Ruby 3.4.
   gem 'mutex_m'
 end
+
+if RUBY_VERSION >= '4.0'
+  # activesupport 6.0 depends on the benchmark gem, which has been extracted as a bundled gem since Ruby 4.0.
+  gem 'benchmark'
+end

--- a/gemfiles/rails6_1.gemfile
+++ b/gemfiles/rails6_1.gemfile
@@ -10,3 +10,8 @@ if RUBY_VERSION >= '3.4'
   # activesupport 6.1 depends on the mutex_m gem, which has been extracted as a bundled gem since Ruby 3.4.
   gem 'mutex_m'
 end
+
+if RUBY_VERSION >= '4.0'
+  # activesupport 6.1 depends on the benchmark gem, which has been extracted as a bundled gem since Ruby 4.0.
+  gem 'benchmark'
+end


### PR DESCRIPTION
Release Note
https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/