### PR TITLE
Include GlobalID in MongoMapper::Document

### DIFF
--- a/lib/mongo_mapper.rb
+++ b/lib/mongo_mapper.rb
@@ -6,6 +6,7 @@ require 'active_model'
 require 'activemodel-serializers-xml'
 require 'mongo_mapper/deprecator'
 require "mongo_mapper/railtie" if defined?(Rails)
+require 'globalid'
 
 I18n.load_path << File.expand_path('../mongo_mapper/locale/en.yml', __FILE__)
 
@@ -70,6 +71,7 @@ module MongoMapper
     autoload :Userstamps,         'mongo_mapper/plugins/userstamps'
     autoload :Validations,        'mongo_mapper/plugins/validations'
     autoload :Touch,              'mongo_mapper/plugins/touch'
+    autoload :GlobalID,            'mongo_mapper/plugins/global_id'
 
     module Associations
       autoload :Base,                         'mongo_mapper/plugins/associations/base'

--- a/lib/mongo_mapper/document.rb
+++ b/lib/mongo_mapper/document.rb
@@ -40,6 +40,7 @@ module MongoMapper
     include Plugins::IdentityMap
     include Plugins::CounterCache
     include Plugins::Shardable
+    include Plugins::GlobalID
 
     included do
       extend Plugins

--- a/lib/mongo_mapper/plugins/global_id.rb
+++ b/lib/mongo_mapper/plugins/global_id.rb
@@ -1,0 +1,8 @@
+# encoding: UTF-8
+module MongoMapper
+  module Plugins
+    module GlobalID
+      include ::GlobalID::Identification
+    end
+  end
+end

--- a/mongo_mapper.gemspec
+++ b/mongo_mapper.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 5.0'
   s.add_dependency 'activemodel',   ">= 5.0"
   s.add_dependency 'activemodel-serializers-xml', "~> 1.0"
+  s.add_dependency 'globalid'
 
   s.add_dependency 'rexml'
 end

--- a/spec/functional/global_id_spec.rb
+++ b/spec/functional/global_id_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe "GlobalID" do
+
+  class TestDocument
+    include MongoMapper::Document
+
+    key :name, String
+  end
+
+  it "generates a valid GlobalID" do
+    doc = TestDocument.create!(name: "Test")
+    doc.to_global_id.should be_a(GlobalID)
+  end
+
+  it "can be found by GlobalID" do
+    doc = TestDocument.create!(name: "Test")
+    global_id = doc.to_global_id
+    found_doc = GlobalID::Locator.locate(global_id)
+    found_doc.should == doc
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,8 @@ end
 
 require 'mongo_mapper'
 
+GlobalID.app = 'MongoMapper'
+
 def Doc(name='Class', &block)
   klass = Class.new
   klass.class_eval do


### PR DESCRIPTION
This allows creating GlobalIDs from a MongoMapper document and the locating the document from the GlobalID.

https://github.com/rails/globalid